### PR TITLE
fix: breaking documentation build due to extentions change in README file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.test import test as TestCommand
 
 ROOT_PATH = os.path.dirname(os.path.realpath(__file__))
 SOURCE_PATH = os.path.join(ROOT_PATH, 'source')
-README_PATH = os.path.join(ROOT_PATH, 'README.rst')
+README_PATH = os.path.join(ROOT_PATH, 'README.md')
 
 # Read version from source.
 with open(


### PR DESCRIPTION
CLICKUP-3eqjq04

due to the changes from README.rst to README.md the setup.py is breaking.
this pr simply changes the extension in the setup.py to make it able to build again the sphinx documentation.