### PR TITLE
feat: Add support for setting additional headers and strictApi

### DIFF
--- a/doc/api_reference/session.rst
+++ b/doc/api_reference/session.rst
@@ -23,6 +23,8 @@ Construct Session instance with API credentials.
     :param Array [options.serverInformationValues=[]]: Optional list of server information values to retrieve.
     :param Object [options.eventHubOptions={}]: Options to configure event hub with.
     :param string [options.clientToken=null]: Client identifier included in update events caused by operations performed by this session.
+    :param Object [options.headers]: Additional headers to send with the request
+    :param Object [options.strictApi]: Turn on strict API mode
 
 Function ``call``
 =================
@@ -45,8 +47,12 @@ ServerError
 
     
     :param Array operations: API operations.
+    :param Object [options]: options
+    :param Object [options.abortController]: - Deprecated in favour of options.signal
+    :param Object [options.signal]: - Abort signal user for aborting requests prematurely
+    :param Object [options.headers]: - Additional headers to send with the request
     
-
+    :return Promise: Promise which will be resolved with an array of decoded responses.
 
 Function ``getSchema``
 ======================

--- a/source/session.ts
+++ b/source/session.ts
@@ -139,6 +139,8 @@ export class Session {
    * @param  {Object}  [options.eventHubOptions={}] - Options to configure event hub with.
    * @param  {string} [options.clientToken] - Client token for update events.
    * @param  {string} [options.apiEndpoint=/api] - API endpoint.
+   * @param {object} [options.headers] - Additional headers to send with the request
+   * @param {object} [options.strictApi] - Turn on strict API mode
    *
    * @constructs Session
    */
@@ -508,6 +510,7 @@ export class Session {
    * @param {AbortController} options.abortController - Abort controller, deprecated in favor of options.signal
    * @param {AbortSignal} options.signal - Abort signal
    * @param {string} options.pushToken - push token to associate with the request
+   * @param {object} options.headers - Additional headers to send with the request
    *
    */
   call(
@@ -730,6 +733,7 @@ export class Session {
    * @param {object} options
    * @param {object} options.abortController - Deprecated in favour of options.signal
    * @param {object} options.signal - Abort signal user for aborting requests prematurely
+   * @param {object} options.headers - Additional headers to send with the request
    * @return {Promise} Promise which will be resolved with an object
    * containing action, data and metadata
    */
@@ -756,6 +760,7 @@ export class Session {
    * @param {object} additionalOptions
    * @param {object} options.abortController - Deprecated in favour of options.signal
    * @param {object} options.signal - Abort signal user for aborting requests prematurely
+   * @param {object} options.headers - Additional headers to send with the request
    * @return {Promise} Promise which will be resolved with an object
    * containing data and metadata
    */
@@ -799,6 +804,7 @@ export class Session {
    * @param {Object} data data which should be used to populate attributes on the entity.
    * @param {Object} options
    * @param {string} options.pushToken - push token to associate with the request
+   * @param {object} options.headers - Additional headers to send with the request
    * @return {Promise} Promise which will be resolved with the response.
    */
   create(entityType: string, data: Data, { pushToken }: CallOptions = {}) {
@@ -822,6 +828,7 @@ export class Session {
    * @param  {Object} data
    * @param {Object} options
    * @param {string} options.pushToken - push token to associate with the request
+   * @param {object} options.headers - Additional headers to send with the request
    * @return {Promise} Promise resolved with the response.
    */
   update(
@@ -849,6 +856,7 @@ export class Session {
    * @param  {Array} keys Identifying keys, typically [<entity id>]
    * @param {Object} options
    * @param {string} options.pushToken - push token to associate with the request
+   * @param {object} options.headers - Additional headers to send with the request
    * @return {Promise} Promise resolved with the response.
    */
   delete(type: string, keys: string[], { pushToken }: MutatationOptions = {}) {

--- a/test/server.js
+++ b/test/server.js
@@ -4,6 +4,8 @@ import fs from "fs/promises";
 import querySchemas from "./fixtures/query_schemas.json";
 import queryServerInformation from "./fixtures/query_server_information.json";
 import getUploadMetadata from "./fixtures/get_upload_metadata.json";
+import exampleQuery from "./fixtures/query_select_name_from_task_limit_1.json";
+import { setupServer } from "msw/node";
 
 function authenticate(req) {
   // allow returning invalid authentication by setting ftrack-api-key to "INVALID_API_KEY"
@@ -21,7 +23,16 @@ function pick(object, keys) {
     return obj;
   }, {});
 }
-const handlers = [
+
+export function getInitialSessionQuery() {
+  return [queryServerInformation, querySchemas];
+}
+
+export function getExampleQuery() {
+  return [exampleQuery];
+}
+
+export const handlers = [
   rest.post("http://ftrack.test/api", async (req, res, ctx) => {
     if (!authenticate(req)) {
       return res(
@@ -111,4 +122,4 @@ const handlers = [
   }),
 ];
 
-export { handlers };
+export const server = setupServer(...handlers);

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,8 +1,5 @@
 import { fetch } from "cross-fetch";
-import { setupServer } from "msw/node";
-import { handlers } from "./test/server";
-
-const server = setupServer(...handlers);
+import { server } from "./test/server";
 
 // Very simple mock of XmlHttpRequest with only the parts we use
 class MockXmlHttpRequest {


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

Resolves FT-1b5069d6-a6dc-11ed-8149-8a547ff3bf63

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

- Adds support for additional custom headers, both on session level and call level
- Adds support for turning on strict API mode

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->

- When strict API is turned on, make sure `ftrack-strict-api: true` is sent as header.