### PR TITLE
feat: Support encoding and decoding of non-moment date objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TZ: Europe/Stockholm
     steps:
       - uses: actions/checkout@v3
       - name: Using Node.js from .nvmrc

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@rollup/plugin-commonjs": "^24.0.1",
     "@types/uuid": "^9.0.0",
     "cross-fetch": "^3.1.5",
+    "dayjs": "^1.11.7",
     "eslint": "^8.33.0",
     "eslint-config-react-app": "^7.0.1",
     "jsdom": "^21.1.0",

--- a/source/session.ts
+++ b/source/session.ts
@@ -16,7 +16,7 @@ import { SERVER_LOCATION_ID } from "./constant";
 
 import normalizeString from "./util/normalize_string";
 import { Data } from "./types";
-import { convertToISOString } from "./util/convert_to_iso_string";
+import { convertToIsoString } from "./util/convert_to_iso_string";
 
 const logger = loglevel.getLogger("ftrack_api");
 
@@ -99,14 +99,14 @@ export interface ResponseError {
 export interface MutationOptions {
   pushToken?: string;
   additionalHeaders?: Data;
-  decodeDatesAsISO?: boolean;
+  decodeDatesAsIso?: boolean;
 }
 
 export interface QueryOptions {
   abortController?: AbortController;
   signal?: AbortSignal;
   additionalHeaders?: Data;
-  decodeDatesAsISO?: boolean;
+  decodeDatesAsIso?: boolean;
 }
 
 export interface CallOptions extends MutationOptions, QueryOptions {}
@@ -144,7 +144,7 @@ export class Session {
    * @param  {string} [options.apiEndpoint=/api] - API endpoint.
    * @param {object} [options.headers] - Additional headers to send with the request
    * @param {object} [options.strictApi] - Turn on strict API mode
-   * @param {object} options.decodeDatesAsISO - Decode dates as ISO strings instead of moment objects
+   * @param {object} options.decodeDatesAsIso - Decode dates as ISO strings instead of moment objects
    *
    * @constructs Session
    */
@@ -333,7 +333,7 @@ export class Session {
       return out;
     }
 
-    const date = convertToISOString(data);
+    const date = convertToIsoString(data);
     if (date) {
       if (
         this.serverInformation &&
@@ -404,21 +404,21 @@ export class Session {
   private decode(
     data: any,
     identityMap: Data = {},
-    decodeDatesAsISO: boolean = false
+    decodeDatesAsIso: boolean = false
   ): any {
     if (Array.isArray(data)) {
-      return this._decodeArray(data, identityMap, decodeDatesAsISO);
+      return this._decodeArray(data, identityMap, decodeDatesAsIso);
     }
     if (typeof data === "object" && data?.constructor === Object) {
       if (data.__entity_type__) {
-        return this._mergeEntity(data, identityMap, decodeDatesAsISO);
+        return this._mergeEntity(data, identityMap, decodeDatesAsIso);
       }
-      if (data.__type__ === "datetime" && decodeDatesAsISO) {
-        return this._decodeDateTimeAsISO(data);
+      if (data.__type__ === "datetime" && decodeDatesAsIso) {
+        return this._decodeDateTimeAsIso(data);
       } else if (data.__type__ === "datetime") {
         return this._decodeDateTimeAsMoment(data);
       }
-      return this._decodePlainObject(data, identityMap, decodeDatesAsISO);
+      return this._decodePlainObject(data, identityMap, decodeDatesAsIso);
     }
     return data;
   }
@@ -431,7 +431,7 @@ export class Session {
    * will be assumed to be UTC and the moment will be in utc.
    * @private
    */
-  private _decodeDateTimeAsISO(data: any) {
+  private _decodeDateTimeAsIso(data: any) {
     let dateValue = data.value;
     if (
       this.serverInformation &&
@@ -477,10 +477,10 @@ export class Session {
   private _decodePlainObject(
     object: Data,
     identityMap: Data,
-    decodeDatesAsISO: boolean
+    decodeDatesAsIso: boolean
   ) {
     return Object.keys(object).reduce<Data>((previous, key) => {
-      previous[key] = this.decode(object[key], identityMap, decodeDatesAsISO);
+      previous[key] = this.decode(object[key], identityMap, decodeDatesAsIso);
       return previous;
     }, {});
   }
@@ -492,10 +492,10 @@ export class Session {
   private _decodeArray(
     collection: any[],
     identityMap: Data,
-    decodeDatesAsISO: boolean
+    decodeDatesAsIso: boolean
   ): any[] {
     return collection.map((item) =>
-      this.decode(item, identityMap, decodeDatesAsISO)
+      this.decode(item, identityMap, decodeDatesAsIso)
     );
   }
 
@@ -506,7 +506,7 @@ export class Session {
   private _mergeEntity(
     entity: Data,
     identityMap: Data,
-    decodeDatesAsISO: boolean
+    decodeDatesAsIso: boolean
   ) {
     const identifier = this.getIdentifyingKey(entity);
     if (!identifier) {
@@ -531,7 +531,7 @@ export class Session {
         mergedEntity[key] = this.decode(
           entity[key],
           identityMap,
-          decodeDatesAsISO
+          decodeDatesAsIso
         );
       }
     }
@@ -564,7 +564,7 @@ export class Session {
    * @param {AbortSignal} options.signal - Abort signal
    * @param {string} options.pushToken - push token to associate with the request
    * @param {object} options.headers - Additional headers to send with the request
-   * @param {string} options.decodeDatesAsISO - Return dates as ISO strings instead of moment objects
+   * @param {string} options.decodeDatesAsIso - Return dates as ISO strings instead of moment objects
    *
    */
   call(
@@ -574,7 +574,7 @@ export class Session {
       pushToken,
       signal,
       additionalHeaders = {},
-      decodeDatesAsISO = false,
+      decodeDatesAsIso = false,
     }: CallOptions = {}
   ): Promise<Response<Data>[]> {
     const url = `${this.serverUrl}${this.apiEndpoint}`;
@@ -629,7 +629,7 @@ export class Session {
       })
       .then((data) => {
         if (this.initialized) {
-          return this.decode(data, {}, decodeDatesAsISO);
+          return this.decode(data, {}, decodeDatesAsIso);
         }
 
         return data;
@@ -712,8 +712,8 @@ export class Session {
 
       if (value != null && typeof value.valueOf() === "string") {
         value = `"${value}"`;
-      } else if (convertToISOString(value)) {
-        value = convertToISOString(value);
+      } else if (convertToIsoString(value)) {
+        value = convertToIsoString(value);
         value = `"${value}"`;
       }
       return `${identifyingKey} is ${value}`;
@@ -787,7 +787,7 @@ export class Session {
    * @param {object} options.abortController - Deprecated in favour of options.signal
    * @param {object} options.signal - Abort signal user for aborting requests prematurely
    * @param {object} options.headers - Additional headers to send with the request
-   * @param {object} options.decodeDatesAsISO - Decode dates as ISO strings instead of moment objects
+   * @param {object} options.decodeDatesAsIso - Decode dates as ISO strings instead of moment objects
    * @return {Promise} Promise which will be resolved with an object
    * containing action, data and metadata
    */
@@ -815,7 +815,7 @@ export class Session {
    * @param {object} options.abortController - Deprecated in favour of options.signal
    * @param {object} options.signal - Abort signal user for aborting requests prematurely
    * @param {object} options.headers - Additional headers to send with the request
-   * @param {object} options.decodeDatesAsISO - Decode dates as ISO strings instead of moment objects
+   * @param {object} options.decodeDatesAsIso - Decode dates as ISO strings instead of moment objects
    * @return {Promise} Promise which will be resolved with an object
    * containing data and metadata
    */
@@ -860,7 +860,7 @@ export class Session {
    * @param {Object} options
    * @param {string} options.pushToken - push token to associate with the request
    * @param {object} options.headers - Additional headers to send with the request
-   * @param {object} options.decodeDatesAsISO - Decode dates as ISO strings instead of moment objects
+   * @param {object} options.decodeDatesAsIso - Decode dates as ISO strings instead of moment objects
    * @return {Promise} Promise which will be resolved with the response.
    */
   create(entityType: string, data: Data, options: MutationOptions = {}) {
@@ -885,7 +885,7 @@ export class Session {
    * @param {Object} options
    * @param {string} options.pushToken - push token to associate with the request
    * @param {object} options.headers - Additional headers to send with the request
-   * @param {object} options.decodeDatesAsISO - Decode dates as ISO strings instead of moment objects
+   * @param {object} options.decodeDatesAsIso - Decode dates as ISO strings instead of moment objects
    * @return {Promise} Promise resolved with the response.
    */
   update(
@@ -915,7 +915,7 @@ export class Session {
    * @param {Object} options
    * @param {string} options.pushToken - push token to associate with the request
    * @param {object} options.headers - Additional headers to send with the request
-   * @param {object} options.decodeDatesAsISO - Decode dates as ISO strings instead of moment objects
+   * @param {object} options.decodeDatesAsIso - Decode dates as ISO strings instead of moment objects
    * @return {Promise} Promise resolved with the response.
    */
   delete(type: string, keys: string[], options: MutationOptions = {}) {

--- a/source/util/convert_to_iso_string.ts
+++ b/source/util/convert_to_iso_string.ts
@@ -1,0 +1,20 @@
+function isIsoDate(str: string) {
+  if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) return false;
+  const d = new Date(str);
+  return d instanceof Date && !isNaN(d.getTime()) && d.toISOString() === str; // valid date
+}
+
+export function convertToISOString(data: string | Date) {
+  if (
+    data &&
+    // if this is a date object of type moment or dayjs, or regular date object (all of them has toISOString)
+    ((typeof data !== "string" && typeof data.toISOString === "function") ||
+      // if it's a ISO string already
+      (typeof data == "string" && isIsoDate(data)))
+  ) {
+    // wrap it new Date() to convert it to UTC based ISO string in case it is in another timezone
+    return new Date(data).toISOString();
+  }
+
+  return null;
+}

--- a/source/util/convert_to_iso_string.ts
+++ b/source/util/convert_to_iso_string.ts
@@ -1,9 +1,19 @@
+/**
+ * Checks if string is in ISO 6801 format.
+ */
 function isIsoDate(str: string) {
   return /^([+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([.,]\d+(?!:))?)?(\17[0-5]\d([.,]\d+)?)?([zZ]|([+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/.test(
     str
   );
 }
 
+/**
+ * Converts a string or date object to ISO 6801 compatible string.
+ * Supports converting regular date objects, or any object that has toISOString() method such as moment or dayjs.
+ *
+ * @param data - string or date object
+ * @returns ISO 6801 compatible string, or null if invalid date
+ */
 export function convertToISOString(data: string | Date) {
   if (
     data &&

--- a/source/util/convert_to_iso_string.ts
+++ b/source/util/convert_to_iso_string.ts
@@ -1,7 +1,7 @@
 function isIsoDate(str: string) {
-  if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(str)) return false;
-  const d = new Date(str);
-  return d instanceof Date && !isNaN(d.getTime()) && d.toISOString() === str; // valid date
+  return /^([+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([.,]\d+(?!:))?)?(\17[0-5]\d([.,]\d+)?)?([zZ]|([+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/.test(
+    str
+  );
 }
 
 export function convertToISOString(data: string | Date) {
@@ -13,7 +13,11 @@ export function convertToISOString(data: string | Date) {
       (typeof data == "string" && isIsoDate(data)))
   ) {
     // wrap it new Date() to convert it to UTC based ISO string in case it is in another timezone
-    return new Date(data).toISOString();
+    try {
+      return new Date(data).toISOString();
+    } catch (err) {
+      return null;
+    }
   }
 
   return null;

--- a/source/util/convert_to_iso_string.ts
+++ b/source/util/convert_to_iso_string.ts
@@ -14,7 +14,7 @@ function isIsoDate(str: string) {
  * @param data - string or date object
  * @returns ISO 6801 compatible string, or null if invalid date
  */
-export function convertToISOString(data: string | Date) {
+export function convertToIsoString(data: string | Date) {
   if (
     data &&
     // if this is a date object of type moment or dayjs, or regular date object (all of them has toISOString)

--- a/test/convert_to_iso_string.test.js
+++ b/test/convert_to_iso_string.test.js
@@ -1,42 +1,42 @@
 // :copyright: Copyright (c) 2022 ftrack
 
-import { convertToISOString } from "../source/util/convert_to_iso_string";
+import { convertToIsoString } from "../source/util/convert_to_iso_string";
 import moment from "moment";
 import dayjs from "dayjs";
 
-describe("convertToISOString", () => {
+describe("convertToIsoString", () => {
   it("should convert date object to ISO", () => {
     const isoDate = "2023-01-01T00:00:00.000Z";
     const date = new Date(isoDate);
-    const converted = convertToISOString(date);
+    const converted = convertToIsoString(date);
     expect(converted).toEqual(isoDate);
   });
 
   it("should return ISO in UTC to itself", () => {
     const isoDate = "2023-01-01T00:00:00.000Z";
     const date = new Date(isoDate);
-    const converted = convertToISOString(date);
+    const converted = convertToIsoString(date);
     expect(converted).toEqual(isoDate);
   });
 
   it("should convert ISO string with other timezone to UTC", () => {
     const tzDate = "2023-01-01T01:00:00+01:00";
     const isoDate = "2023-01-01T00:00:00.000Z";
-    const converted = convertToISOString(tzDate);
+    const converted = convertToIsoString(tzDate);
     expect(converted).toEqual(isoDate);
   });
 
   it("should convert moment objects to ISO strings in UTC", () => {
     const tzDate = "2023-01-01T01:00:00+01:00";
     const isoDate = "2023-01-01T00:00:00.000Z";
-    const converted = convertToISOString(moment(tzDate));
+    const converted = convertToIsoString(moment(tzDate));
     expect(converted).toEqual(isoDate);
   });
 
   it("should convert dayjs objects to ISO strings", () => {
     const tzDate = "2023-01-01T01:00:00+01:00";
     const isoDate = "2023-01-01T00:00:00.000Z";
-    const converted = convertToISOString(dayjs(tzDate));
+    const converted = convertToIsoString(dayjs(tzDate));
     expect(converted).toEqual(isoDate);
   });
 
@@ -55,7 +55,7 @@ describe("convertToISOString", () => {
     new Date("hello world"),
     NaN,
   ])("should return null for invalid ISO string: %s", (invalidDate) => {
-    const converted = convertToISOString(invalidDate);
+    const converted = convertToIsoString(invalidDate);
     expect(converted).toEqual(null);
   });
 });

--- a/test/convert_to_iso_string.test.js
+++ b/test/convert_to_iso_string.test.js
@@ -1,0 +1,61 @@
+// :copyright: Copyright (c) 2022 ftrack
+
+import { convertToISOString } from "../source/util/convert_to_iso_string";
+import moment from "moment";
+import dayjs from "dayjs";
+
+describe("convertToISOString", () => {
+  it("should convert date object to ISO", () => {
+    const isoDate = "2023-01-01T00:00:00.000Z";
+    const date = new Date(isoDate);
+    const converted = convertToISOString(date);
+    expect(converted).toEqual(isoDate);
+  });
+
+  it("should return ISO in UTC to itself", () => {
+    const isoDate = "2023-01-01T00:00:00.000Z";
+    const date = new Date(isoDate);
+    const converted = convertToISOString(date);
+    expect(converted).toEqual(isoDate);
+  });
+
+  it("should convert ISO string with other timezone to UTC", () => {
+    const tzDate = "2023-01-01T01:00:00+01:00";
+    const isoDate = "2023-01-01T00:00:00.000Z";
+    const converted = convertToISOString(tzDate);
+    expect(converted).toEqual(isoDate);
+  });
+
+  it("should convert moment objects to ISO strings in UTC", () => {
+    const tzDate = "2023-01-01T01:00:00+01:00";
+    const isoDate = "2023-01-01T00:00:00.000Z";
+    const converted = convertToISOString(moment(tzDate));
+    expect(converted).toEqual(isoDate);
+  });
+
+  it("should convert dayjs objects to ISO strings", () => {
+    const tzDate = "2023-01-01T01:00:00+01:00";
+    const isoDate = "2023-01-01T00:00:00.000Z";
+    const converted = convertToISOString(dayjs(tzDate));
+    expect(converted).toEqual(isoDate);
+  });
+
+  it.each([
+    "hello world",
+    "202f",
+    "ffff",
+    "1",
+    "2",
+    "20",
+    1,
+    -1,
+    0,
+    null,
+    undefined,
+    new Date("hello world"),
+    NaN,
+  ])("should return null for invalid ISO string: %s", (invalidDate) => {
+    const converted = convertToISOString(invalidDate);
+    expect(converted).toEqual(null);
+  });
+});

--- a/test/fixtures/query_select_name,_created_at_from_task_limit_1.json
+++ b/test/fixtures/query_select_name,_created_at_from_task_limit_1.json
@@ -1,0 +1,22 @@
+{
+  "action": "query",
+  "data": [
+    {
+      "name": "Filters via \"At a glance\" rendered with different paddings in Filters panel",
+      "created_at": {
+        "__type__": "datetime",
+        "value": "2022-10-10T10:12:09"
+      },
+      "context_type": "task",
+      "__entity_type__": "Task",
+      "object_type_id": "11c137c0-ee7e-4f9c-91c5-8c77cec22b2c",
+      "project_id": "95f5c536-4e65-11e1-afaa-f23c91df25eb",
+      "id": "00a574b0-1c44-11e2-a9da-f23c91df25eb"
+    }
+  ],
+  "metadata": {
+    "next": {
+      "offset": 1
+    }
+  }
+}

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -523,7 +523,7 @@ describe("Session", () => {
       {
         foo: {
           __type__: "datetime",
-          value: now.format("YYYY-MM-DDTHH:mm:ss"),
+          value: now.toISOString(),
         },
         bar: "baz",
       },

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -130,7 +130,7 @@ describe("Session", () => {
   it("Should allow querying with datetimes decoded as ISO objects", async () => {
     const result = await session.query(
       "select name, created_at from Task limit 1",
-      { decodeDatesAsISO: true }
+      { decodeDatesAsIso: true }
     );
     expect(result.data[0].created_at).toEqual("2022-10-10T10:12:09.000Z");
   });
@@ -156,7 +156,7 @@ describe("Session", () => {
     );
     const result = await timezoneDisabledSession.query(
       "select name, created_at from Task limit 1",
-      { decodeDatesAsISO: true }
+      { decodeDatesAsIso: true }
     );
     expect(result.data[0].created_at).toEqual("2022-10-10T08:12:09.000Z");
   });
@@ -665,7 +665,7 @@ describe("Encoding entities", () => {
           },
         },
         {},
-        { decodeDatesAsISO: true }
+        { decodeDatesAsIso: true }
       );
       expect(output.foo).toEqual(now.toISOString());
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,6 +1778,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^24.0.1
     "@types/uuid": ^9.0.0
     cross-fetch: ^3.1.5
+    dayjs: ^1.11.7
     eslint: ^8.33.0
     eslint-config-react-app: ^7.0.1
     jsdom: ^21.1.0
@@ -3332,6 +3333,13 @@ __metadata:
     whatwg-mimetype: ^3.0.0
     whatwg-url: ^11.0.0
   checksum: 033fc3dd0fba6d24bc9a024ddcf9923691dd24f90a3d26f6545d6a2f71ec6956f93462f2cdf2183cc46f10dc01ed3bcb36731a8208456eb1a08147e571fe2a76
+  languageName: node
+  linkType: hard
+
+"dayjs@npm:^1.11.7":
+  version: 1.11.7
+  resolution: "dayjs@npm:1.11.7"
+  checksum: 5003a7c1dd9ed51385beb658231c3548700b82d3548c0cfbe549d85f2d08e90e972510282b7506941452c58d32136d6362f009c77ca55381a09c704e9f177ebb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

Resolves FT-bc5b3fba-b1ca-11ed-ba1e-a2da51ff8a88

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

As part of easing migration from moment, as described in https://github.com/ftrackhq/ftrack-javascript/issues/71 , we start by supporting encoding of non-moment date objects. This includes all date libraries that have `toISOString` as a method on their date objects, as well as native `Date` library, and also an ISO6801 compatible string.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->

Make sure encoding all these date formats work as expected.
