### PR TITLE
fix: documentation building

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -8,7 +8,12 @@ Release Notes
 *************
 
 .. release:: Upcoming
-    
+
+    .. change:: fixed
+        :tags: documentation
+
+        Documentation does not build on readthedocs.
+
     .. change:: new
         :tags: Event hub, Dependencies
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -7,7 +7,8 @@
 Release Notes
 *************
 
-.. release:: upcoming
+.. release:: Upcoming
+    
     .. change:: new
         :tags: Event hub, Dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ftrack/api",
   "description": "JavaScript API for ftrack.",
+  "version": "0.9.1",
   "scripts": {
     "lint": "tsc && eslint . && prettier -c .",
     "test": "vitest --run test && yarn lint",


### PR DESCRIPTION
- [ ] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

You can locally test the doc builds with:

python setup.py build_sphinx