### PR TITLE
fix: Re-add previously removed non-standard functionality of passing blobs with name properties

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -939,9 +939,13 @@ export class Session {
     file: Blob,
     options: CreateComponentOptions = {}
   ): Promise<Response<Data>[]> {
-    const normalizedFileName = normalizeString(
-      options.name ?? (file instanceof File ? file.name : "component")
-    );
+    const componentName = options.name ?? (file as File).name;
+
+    let normalizedFileName;
+    if (componentName) {
+      normalizedFileName = normalizeString(componentName);
+    }
+
     if (!normalizedFileName) {
       throw new CreateComponentError("Component name is missing.");
     }


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

During typescript migration we removed possibility to pass Blob instances with name properties. This is non-standard, and the recommended fix is to pass `options.name` instead. But re-adding this functionality since we have instances that rely on this.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->

Make sure you can add Blobs with name properties.

Test it by installing dependency: `yarn up @ftrack/api@https://github.com/ftrackhq/ftrack-javascript.git#fix/blob-name`.