### PR TITLE
chore: Add types to exports property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/ftrack-javascript-api.es.js",
       "require": "./dist/ftrack-javascript-api.umd.js"
     }


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

When setting moduleresolution: "nodenext" in tsconfig, it started complaining about missing types. This is due to missing types property in the exports property in package.json.


## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
