### PR TITLE
feat: Use type discriminators for event payload.

### DIFF
--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -578,7 +578,9 @@ export class EventHub {
    */
   _handleReply(eventPayload: EventPayload) {
     this.logger.debug("Reply received", eventPayload);
-    const onReplyCallback = this._replyCallbacks[eventPayload.inReplyToEvent];
+    const onReplyCallback = !eventPayload.inReplyToEvent
+      ? null
+      : this._replyCallbacks[eventPayload.inReplyToEvent];
     if (onReplyCallback) {
       onReplyCallback(eventPayload);
     }

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -20,9 +20,10 @@ interface BaseActionData {
 
 interface BaseEventPayload {
   target: string;
-  inReplyToEvent: string;
   source: EventSource;
   id: string;
+  inReplyToEvent?: string;
+  sent?: boolean;
 }
 
 export interface ActionDiscoverEventPayload extends BaseEventPayload {
@@ -32,8 +33,9 @@ export interface ActionDiscoverEventPayload extends BaseEventPayload {
 
 export interface ActionLaunchEventData extends BaseActionData {
   actionIdentifier: string;
-  description: string;
-  label: string;
+  description?: string;
+  label?: string;
+  applicationIdentifier?: string;
 }
 
 export interface ActionLaunchEventPayload extends BaseEventPayload {

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -13,10 +13,10 @@ import { Data } from "./types";
 
 type BaseActionData = {
   selection: Array<{
-    entityId: string,
-    entityType: string
+    entityId: string;
+    entityType: string;
   }>;
-}
+};
 
 type BaseEventPayload = {
   target: string;
@@ -28,18 +28,18 @@ type BaseEventPayload = {
 export type ActionDiscoverEventPayload = BaseEventPayload & {
   topic: "ftrack.action.discover";
   data: BaseActionData;
-}
+};
 
 export type ActionLaunchEventData = BaseActionData & {
   actionIdentifier: string;
   description: string;
   label: string;
-}
+};
 
 export type ActionLaunchEventPayload = BaseEventPayload & {
   topic: "ftrack.action.launch";
   data: ActionLaunchEventData;
-}
+};
 
 export interface UpdateEventData {
   entities: EventEntity[];
@@ -55,12 +55,12 @@ export interface UpdateEventData {
 export type UpdateEventPayload = BaseEventPayload & {
   topic: "ftrack.update";
   data: UpdateEventData;
-}
+};
 
 export type EventPayload =
-  ActionLaunchEventPayload |
-  ActionDiscoverEventPayload |
-  UpdateEventPayload;
+  | ActionLaunchEventPayload
+  | ActionDiscoverEventPayload
+  | UpdateEventPayload;
 
 export interface EventSource {
   clientToken: string;

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -11,35 +11,35 @@ import {
 } from "./error";
 import { Data } from "./types";
 
-type BaseActionData = {
+interface BaseActionData {
   selection: Array<{
     entityId: string;
     entityType: string;
   }>;
-};
+}
 
-type BaseEventPayload = {
+interface BaseEventPayload {
   target: string;
   inReplyToEvent: string;
   source: EventSource;
   id: string;
-};
+}
 
-export type ActionDiscoverEventPayload = BaseEventPayload & {
+export interface ActionDiscoverEventPayload extends BaseEventPayload {
   topic: "ftrack.action.discover";
   data: BaseActionData;
-};
+}
 
-export type ActionLaunchEventData = BaseActionData & {
+export interface ActionLaunchEventData extends BaseActionData {
   actionIdentifier: string;
   description: string;
   label: string;
-};
+}
 
-export type ActionLaunchEventPayload = BaseEventPayload & {
+export interface ActionLaunchEventPayload extends BaseEventPayload {
   topic: "ftrack.action.launch";
   data: ActionLaunchEventData;
-};
+}
 
 export interface UpdateEventData {
   entities: EventEntity[];
@@ -52,19 +52,21 @@ export interface UpdateEventData {
   clientToken: string;
 }
 
-export type UpdateEventPayload = BaseEventPayload & {
+export interface UpdateEventPayload extends BaseEventPayload {
   topic: "ftrack.update";
   data: UpdateEventData;
-};
+}
+
+export interface UnknownEventPayload extends BaseEventPayload {
+  topic: unknown;
+  data: unknown;
+}
 
 export type EventPayload =
   | ActionLaunchEventPayload
   | ActionDiscoverEventPayload
   | UpdateEventPayload
-  | {
-      topic: unknown;
-      data: unknown;
-    };
+  | UnknownEventPayload;
 
 export interface EventSource {
   clientToken: string;

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -60,7 +60,11 @@ export type UpdateEventPayload = BaseEventPayload & {
 export type EventPayload =
   | ActionLaunchEventPayload
   | ActionDiscoverEventPayload
-  | UpdateEventPayload;
+  | UpdateEventPayload
+  | {
+      topic: unknown;
+      data: unknown;
+    };
 
 export interface EventSource {
   clientToken: string;

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -11,14 +11,56 @@ import {
 } from "./error";
 import { Data } from "./types";
 
-export interface EventPayload {
+type BaseActionData = {
+  selection: Array<{
+    entityId: string,
+    entityType: string
+  }>;
+}
+
+type BaseEventPayload = {
   target: string;
   inReplyToEvent: string;
-  topic: string;
   source: EventSource;
-  data: EventData;
   id: string;
+};
+
+export type ActionDiscoverEventPayload = BaseEventPayload & {
+  topic: "ftrack.action.discover";
+  data: BaseActionData;
 }
+
+export type ActionLaunchEventData = BaseActionData & {
+  actionIdentifier: string;
+  description: string;
+  label: string;
+}
+
+export type ActionLaunchEventPayload = BaseEventPayload & {
+  topic: "ftrack.action.launch";
+  data: ActionLaunchEventData;
+}
+
+export interface UpdateEventData {
+  entities: EventEntity[];
+  pushToken: string;
+  parents: string[];
+  user: {
+    userid: string;
+    name: string;
+  };
+  clientToken: string;
+}
+
+export type UpdatedEventPayload = BaseEventPayload & {
+  topic: "ftrack.update";
+  data: UpdateEventData;
+}
+
+export type EventPayload =
+  ActionLaunchEventPayload |
+  ActionDiscoverEventPayload |
+  UpdatedEventPayload;
 
 export interface EventSource {
   clientToken: string;
@@ -28,17 +70,6 @@ export interface EventSource {
     id: string;
   };
   id: string;
-}
-
-export interface EventData {
-  entities: EventEntity[];
-  pushToken: string;
-  parents: string[];
-  user: {
-    userid: string;
-    name: string;
-  };
-  clientToken: string;
 }
 
 export interface EventEntity {

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -44,14 +44,14 @@ export interface ActionLaunchEventPayload extends BaseEventPayload {
 }
 
 export interface UpdateEventData {
-  entities: EventEntity[];
-  pushToken: string;
-  parents: string[];
-  user: {
+  entities?: EventEntity[];
+  pushToken?: string;
+  parents?: string[];
+  user?: {
     userid: string;
     name: string;
   };
-  clientToken: string;
+  clientToken?: string;
 }
 
 export interface UpdateEventPayload extends BaseEventPayload {
@@ -81,20 +81,20 @@ export interface EventSource {
 }
 
 export interface EventEntity {
-  entity_type: string;
-  keys: string[];
-  objectTypeId: string;
-  entityType: string;
-  parents: {
+  entity_type?: string;
+  keys?: string[];
+  objectTypeId?: string;
+  entityType?: string;
+  parents?: {
     entityId: string;
     entityType: string;
     entity_type: string;
     parentId?: string;
   }[];
-  parentId: string;
-  action: string;
-  entityId: string;
-  changes: Data;
+  parentId?: string;
+  action?: string;
+  entityId?: string;
+  changes?: Data;
 }
 
 export interface SubscriberMetadata {

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -52,7 +52,7 @@ export interface UpdateEventData {
   clientToken: string;
 }
 
-export type UpdatedEventPayload = BaseEventPayload & {
+export type UpdateEventPayload = BaseEventPayload & {
   topic: "ftrack.update";
   data: UpdateEventData;
 }
@@ -60,7 +60,7 @@ export type UpdatedEventPayload = BaseEventPayload & {
 export type EventPayload =
   ActionLaunchEventPayload |
   ActionDiscoverEventPayload |
-  UpdatedEventPayload;
+  UpdateEventPayload;
 
 export interface EventSource {
   clientToken: string;


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [X] I have added automatic tests where applicable
- [X] The PR title is suitable as a release note
- [X] The PR contains a description of what has been changed
- [X] The description contains manual test instructions

## Changes
Currently, there are two main issues with the typings of Ftrack events.

1. The `EventData` type is sometimes incorrect. It assumes that the data for the event is always for an `ftrack.update` event. So for most other events, the type is incorrect, which is a bug in my opinion.
2. It doesn't support type discriminators to intelligently determine the type. You end up with quite a lot of type casts etc.

Here's an example that explains the issue before my pull request.

```typescript
eventHub.subscribe('topic=ftrack.update', event => {
   //here, before this pull request, event.data is of type EventData which is correct for the ftrack.update event
});

eventHub.subscribe('topic=ftrack.action.discover', event => {
   //here, before this pull request, event.data is still of type EventData which is incorrect for the ftrack.action.discover event
});
```

After my pull request, the TypeScript compiler understands the discriminator and can narrow the event down without casting.

```typescript
eventHub.subscribe("some-query", event => {
  if(event.topic === "ftrack.action.discover") {
    //event.data is now of type ActionDiscoverEventPayload automatically!
    const firstSelection = event.data.selection[0]; //this doesn't give compile errors!
  } else if(event.topic === "ftrack.update") {
    //event.data is now of type UpdateEventPayload automatically!
    const firstEntity = event.data.entities[0]; //this doesn't give compile errors!
  } else {
    //here, event.data is now of type unknown.
  }
})
```

## Test
It should be tested by running tests and compiling the code. This has already been done.