### PR TITLE
feat: Add mixin to schema

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -181,6 +181,9 @@ type RefSchemaProperty = {
 type SchemaProperties = {
   [key: string]: TypedSchemaProperty | RefSchemaProperty;
 };
+export type SchemaMixin = {
+  $ref: string;
+};
 export interface Schema {
   properties: SchemaProperties;
   default_projections: string[];
@@ -192,6 +195,7 @@ export interface Schema {
   computed?: string[];
   system_projections?: string[];
   alias_for?: string | Data;
+  $mixin?: SchemaMixin;
 }
 export interface QueryOptions {
   abortController?: AbortController;

--- a/source/types.ts
+++ b/source/types.ts
@@ -161,24 +161,26 @@ export interface MutationOptions {
   decodeDatesAsIso?: boolean;
 }
 
-type SimpleTypeSchemaProperty = {
+export type SimpleTypeSchemaProperty = {
   type: "string" | "boolean" | "number" | "integer" | "variable";
   format?: string;
   description?: string;
   alias_for?: string;
   default?: string;
 };
-type ArrayTypeSchemaProperty = {
+export type ArrayTypeSchemaProperty = {
   type: "array" | "mapped_array";
   items: RefSchemaProperty;
   description?: string;
   alias_for?: string;
 };
-type TypedSchemaProperty = SimpleTypeSchemaProperty | ArrayTypeSchemaProperty;
-type RefSchemaProperty = {
+export type TypedSchemaProperty =
+  | SimpleTypeSchemaProperty
+  | ArrayTypeSchemaProperty;
+export type RefSchemaProperty = {
   ["$ref"]: string;
 };
-type SchemaProperties = {
+export type SchemaProperties = {
   [key: string]: TypedSchemaProperty | RefSchemaProperty;
 };
 export type SchemaMixin = {


### PR DESCRIPTION
- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

A $mixin property was recently added to the schema in ftrack to give inheritance information for the data types. I've added that to the interface and exported a few more types.

## Test

Does it quack like a duck and walk like a duck? And also compile :)
