### PR TITLE
fix: Library couldn't be imported as ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "prepack": "yarn build",
     "prepublish": "yarn test"
   },
-  "main": "./dist/ftrack-javascript-api.umd.js",
+  "type": "module",
+  "main": "./dist/ftrack-javascript-api.umd.cjs",
   "module": "./dist/ftrack-javascript-api.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/ftrack-javascript-api.es.js",
-      "require": "./dist/ftrack-javascript-api.umd.js"
+      "require": "./dist/ftrack-javascript-api.umd.cjs"
     }
   },
   "files": [
@@ -43,8 +44,7 @@
   "keywords": [
     "ftrack",
     "api",
-    "library",
-    "umd"
+    "library"
   ],
   "author": "ftrack",
   "license": "Apache-2.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, "source/index.ts"),
       name: "ftrack-javascript-api",
-      fileName: (format) => `ftrack-javascript-api.${format}.js`,
+      fileName: (format) =>
+        `ftrack-javascript-api.${format}.${format === "umd" ? "cjs" : "js"}`,
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

Without setting type: "module", the library couldn't be imported as es module. This caused it to throw the following error when trying to `import { Session }` from an ES module:

```
SyntaxError: Named export 'Session' not found. The requested module '@ftrack/api' is a CommonJS module, which may not support all module.exports as named exports.
```

By changing the name of the umd package to use `cjs` file ending, it is still working properly as a CJS module as well, not causing any breaking changes.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->

Try to import it in both a CJS and ESM setting, making sure it's working as expected in both.

Example:

test.mjs:
```
import { Session } from "@ftrack/api";
```

test.cjs:
```
const { Session } = require("@ftrack/api");
```