### PR TITLE
fix: bug in typings after recent PR

### DIFF
--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -59,7 +59,14 @@ export interface UpdateEventPayload extends BaseEventPayload {
   data: UpdateEventData;
 }
 
-export type EventPayload =
+/**
+ * A union type of the different payload types with the 
+ * `topic:` property as a type discriminator.
+ * Supports the topics `ftrack.action.discover`, `ftrack.action.launch`
+ * and `ftrack.update`. Please add a GitHub issue for any missing core topics.
+ * @interface EventPayload
+ */
+ export type EventPayload =
   | ActionLaunchEventPayload
   | ActionDiscoverEventPayload
   | UpdateEventPayload;

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -59,16 +59,10 @@ export interface UpdateEventPayload extends BaseEventPayload {
   data: UpdateEventData;
 }
 
-export interface UnknownEventPayload extends BaseEventPayload {
-  topic: unknown;
-  data: unknown;
-}
-
 export type EventPayload =
   | ActionLaunchEventPayload
   | ActionDiscoverEventPayload
-  | UpdateEventPayload
-  | UnknownEventPayload;
+  | UpdateEventPayload;
 
 export interface EventSource {
   clientToken: string;

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -60,13 +60,13 @@ export interface UpdateEventPayload extends BaseEventPayload {
 }
 
 /**
- * A union type of the different payload types with the 
+ * A union type of the different payload types with the
  * `topic:` property as a type discriminator.
  * Supports the topics `ftrack.action.discover`, `ftrack.action.launch`
  * and `ftrack.update`. Please add a GitHub issue for any missing core topics.
  * @interface EventPayload
  */
- export type EventPayload =
+export type EventPayload =
   | ActionLaunchEventPayload
   | ActionDiscoverEventPayload
   | UpdateEventPayload;


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [X] I have added automatic tests where applicable
- [X] The PR title is suitable as a release note
- [X] The PR contains a description of what has been changed
- [X] The description contains manual test instructions

## Changes
I removed the Unknown event type. It ruins the type discrimination it seems. Not sure how this was not caught by me earlier. Apologies. Didn't discover this until I had to consume the event myself.

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test
Test that the types are still OK.
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
