### PR TITLE
fix: better error messages

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -560,7 +560,7 @@ export class Session {
         if (reason instanceof Error) {
           throw this.getErrorFromResponse({
             exception: "NetworkError",
-            content: reason.message,
+            content: (reason.cause as string) || reason.message
           });
         }
         throw new Error("Unknown error");

--- a/source/session.ts
+++ b/source/session.ts
@@ -560,7 +560,7 @@ export class Session {
         if (reason instanceof Error) {
           throw this.getErrorFromResponse({
             exception: "NetworkError",
-            content: (reason.cause as string) || reason.message
+            content: (reason.cause as string) || reason.message,
           });
         }
         throw new Error("Unknown error");


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [X] I have added automatic tests where applicable
- [X] The PR title is suitable as a release note
- [X] The PR contains a description of what has been changed
- [X] The description contains manual test instructions

## Changes
I was trying to use the awesome and brand new Schema Generator (https://github.com/ftrackhq/ftrack-ts-schema-generator).

However, I got the following error:

```
Failed to perform request.  CustomError [ServerError]: fetch failed
    at Session.getErrorFromResponse (/Users/Documents/src/ftrack-javascript/source/session.ts:336:19)
    at Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:561:22)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:534:5)
    at async Session.query (/Users/Documents/src/ftrack-javascript/source/session.ts:738:23) {
  errorCode: undefined
}
Server reported error in unexpected format.  CustomError [ServerError]: fetch failed
    at Session.getErrorFromResponse (/Users/Documents/src/ftrack-javascript/source/session.ts:336:19)
    at Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:561:22)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:534:5)
    at async Session.query (/Users/Documents/src/ftrack-javascript/source/session.ts:738:23) {
  errorCode: undefined
}
/Users/Documents/src/ftrack-javascript/source/session.ts:336
    const error = new ErrorClass(response.content, response.error_code);
                  ^
CustomError [ServerError]: fetch failed
    at Session.getErrorFromResponse (/Users/Documents/src/ftrack-javascript/source/session.ts:336:19)
    at Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:588:20)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:534:5)
    at async Session.query (/Users/Documents/src/ftrack-javascript/source/session.ts:738:23) {
  errorCode: undefined
}
```

This wasn't very useful, so I made this pull request. After that pull request, the error was instead way more helpful:

```
Failed to perform request.  CustomError [ServerError]: Error: unable to verify the first certificate
    at Session.getErrorFromResponse (/Users/Documents/src/ftrack-javascript/source/session.ts:336:19)
    at Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:561:22)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:534:5)
    at async Session.query (/Users/Documents/src/ftrack-javascript/source/session.ts:738:23) {
  errorCode: undefined
}
Server reported error in unexpected format.  CustomError [ServerError]: Error: unable to verify the first certificate
    at Session.getErrorFromResponse (/Users/Documents/src/ftrack-javascript/source/session.ts:336:19)
    at Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:561:22)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:534:5)
    at async Session.query (/Users/Documents/src/ftrack-javascript/source/session.ts:738:23) {
  errorCode: undefined
}
/Users/Documents/src/ftrack-javascript/source/session.ts:336
    const error = new ErrorClass(response.content, response.error_code);
                  ^
CustomError [ServerError]: Error: unable to verify the first certificate
    at Session.getErrorFromResponse (/Users/Documents/src/ftrack-javascript/source/session.ts:336:19)
    at Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:588:20)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Session.call (/Users/Documents/src/ftrack-javascript/source/session.ts:534:5)
    at async Session.query (/Users/Documents/src/ftrack-javascript/source/session.ts:738:23) {
  errorCode: undefined
}
```

This allowed me to truly figure out that it was a company-related VPN thing that caused the issue, and that I needed some certificate changes.

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test
I tried the following test - it provides a much better error message now:

```typescript
import { Session } from '@ftrack/api';

const client = new Session();
client.query("select id from Project").then(console.log);
```

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
