### PR TITLE
fix: Don't include api user and api key as header value to socket.io to resolve CORS issues

### DIFF
--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -140,11 +140,9 @@ export default class SimpleSocketIOClient {
     try {
       const url = new URL(`${this.serverUrl}/socket.io/1/`);
       url.searchParams.append("api_user", this.apiUser);
+      url.searchParams.append("api_key", this.apiKey);
       const response = await fetch(url, {
-        headers: {
-          "ftrack-api-user": this.apiUser,
-          "ftrack-api-key": this.apiKey,
-        },
+        mode: "cors",
         method: "GET",
       });
       if (!response.ok) {


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

Seeing CORS issues when testing this due to including api-user and api key as headers when fetching the session id. This removes these fields, as they are not necessary..

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
