### PR TITLE
fix: Single-part uploads not retried when request fails

### DIFF
--- a/source/uploader.ts
+++ b/source/uploader.ts
@@ -230,7 +230,6 @@ export class Uploader {
       logger.debug("Upload complete", this.componentId);
     } catch (error) {
       try {
-        this.abort();
         await this.cleanup();
       } catch (cleanupError) {
         logger.error("Clean up failed", cleanupError);

--- a/source/uploader.ts
+++ b/source/uploader.ts
@@ -229,6 +229,12 @@ export class Uploader {
       });
       logger.debug("Upload complete", this.componentId);
     } catch (error) {
+      try {
+        this.abort();
+        await this.cleanup();
+      } catch (cleanupError) {
+        logger.error("Clean up failed", cleanupError);
+      }
       if (this.onError) {
         this.onError(error as Error);
       }
@@ -464,16 +470,15 @@ export class Uploader {
       );
       this.xhr.open("PUT", url, true);
       this.xhr.onabort = async () => {
+        this.aborted = true;
         if (this.onAborted) {
           this.onAborted();
         }
-        await this.cleanup();
         reject(
           new CreateComponentError("Upload aborted by client", "UPLOAD_ABORTED")
         );
       };
       this.xhr.onerror = async () => {
-        await this.cleanup();
         reject(
           new CreateComponentError(`Failed to upload file: ${this.xhr!.status}`)
         );


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

Resolves FT-6488286c-04b7-4f74-a46a-991236937e79

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

Single-part uploads tried to cleanup after a failed upload attempt, causing the exponential back-off to not work as expected. Moved the cleanup to after all attempts fail. 

Also set the aborted flag so that an upload that is aborted using the XHR option is not retried again.

## Test

Test together with https://github.com/ftrackhq/frontend/pull/714

Block the upload domain:

![image](https://github.com/ftrackhq/ftrack-javascript/assets/186534/760553ed-0c32-4620-9fe2-0d3a61954383)

Attempt to upload a file < 16 MB, and verify that if you then unblock the domain again it succeeds.