### PR TITLE
feat: Implement asynchronous getSchemas method and prepare for not querying schemas and server information on initialization

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -61,7 +61,7 @@ export class Session {
   serverVersion?: string;
   private schemasPromise?: Promise<Schema[]>;
   private serverInformationPromise?: Promise<ServerInformation>;
-  private serverInformationValues: string[];
+  private serverInformationValues?: string[];
 
   /**
    * Construct Session instance with API credentials.
@@ -87,7 +87,7 @@ export class Session {
     apiKey: string,
     {
       autoConnectEventHub = false,
-      serverInformationValues = [],
+      serverInformationValues,
       eventHubOptions = {},
       clientToken,
       apiEndpoint = "/api",
@@ -171,7 +171,10 @@ export class Session {
 
     // Always include is_timezone_support_enabled as required by API.
     // TODO: Remove this in next major.
-    if (!serverInformationValues.includes("is_timezone_support_enabled")) {
+    if (
+      serverInformationValues &&
+      !serverInformationValues.includes("is_timezone_support_enabled")
+    ) {
       serverInformationValues.push("is_timezone_support_enabled");
     }
 

--- a/source/session.ts
+++ b/source/session.ts
@@ -519,7 +519,7 @@ export class Session {
   /**
    * Returns server version for the session, using serverInformationValues as set on session initialization.
    * This is cached after the first call, and assumes that the server information will not change during the session.
-   * @returns Promise with the server information for the session.
+   * @returns Promise with the server version for the session.
    */
   async getServerVersion(): Promise<string> {
     return (await this.getServerInformation()).version;

--- a/source/session.ts
+++ b/source/session.ts
@@ -192,15 +192,23 @@ export class Session {
      */
     this.initialized = false;
 
+    const initializingPromise =
+      this.call<[QueryServerInformationResponse, QuerySchemasResponse]>(
+        operations
+      );
+
+    this.serverInformationPromise = initializingPromise.then(
+      (responses) => responses[0]
+    );
+    this.schemasPromise = initializingPromise.then((responses) => responses[1]);
+
     /**
      * Resolved once session is initialized.
      * @memberof Session
      * @instance
      * @type {Promise}
      */
-    this.initializing = this.call<
-      [QueryServerInformationResponse, QuerySchemasResponse]
-    >(operations).then((responses) => {
+    this.initializing = initializingPromise.then((responses) => {
       // TODO: Make this.serverInformation, this.schemas, and this.serverVersion private in next major
       // and require calling getServerInformation, getSchemas, and this.getServerVersion instead.
       this.serverInformation = responses[0];

--- a/source/session.ts
+++ b/source/session.ts
@@ -197,11 +197,6 @@ export class Session {
         operations
       );
 
-    this.serverInformationPromise = initializingPromise.then(
-      (responses) => responses[0]
-    );
-    this.schemasPromise = initializingPromise.then((responses) => responses[1]);
-
     /**
      * Resolved once session is initialized.
      * @memberof Session
@@ -218,6 +213,14 @@ export class Session {
 
       return Promise.resolve(this);
     });
+
+    this.serverInformationPromise = initializingPromise
+      .then((responses) => responses[0])
+      .catch(() => ({} as ServerInformation));
+
+    this.schemasPromise = initializingPromise
+      .then((responses) => responses[1])
+      .catch(() => [] as Schema[]);
   }
 
   /**
@@ -506,7 +509,8 @@ export class Session {
         ]
       ).then((responses) => responses[0]);
     }
-    return await this.serverInformationPromise;
+
+    return this.serverInformationPromise;
   }
 
   /**
@@ -529,7 +533,7 @@ export class Session {
         { action: "query_schemas" },
       ]).then((responses) => responses[0]);
     }
-    return await this.schemasPromise;
+    return this.schemasPromise;
   }
 
   /**
@@ -567,7 +571,9 @@ export class Session {
       decodeDatesAsIso = false,
     }: CallOptions = {}
   ): Promise<IsTuple<T> extends true ? T : T[]> {
-    await this.initializing;
+    if (this.initializing) {
+      await this.initializing;
+    }
     const url = `${this.serverUrl}${this.apiEndpoint}`;
 
     try {

--- a/source/session.ts
+++ b/source/session.ts
@@ -514,7 +514,7 @@ export class Session {
   }
 
   /**
-   * Returns server information for the session, using serverInformationValues as set on session initialization.
+   * Returns server version for the session, using serverInformationValues as set on session initialization.
    * This is cached after the first call, and assumes that the server information will not change during the session.
    * @returns Promise with the server information for the session.
    */

--- a/source/types.ts
+++ b/source/types.ts
@@ -68,7 +68,9 @@ export interface ResetRemoteResponse {
   data: Data;
 }
 export type QuerySchemasResponse = Schema[];
-export interface QueryServerInformationResponse {
+
+export type QueryServerInformationResponse = ServerInformation;
+export interface ServerInformation {
   custom_widget?: Data;
   default_colors?: string[];
   is_nested_subqueries_enabled?: boolean;
@@ -91,7 +93,7 @@ export interface QueryServerInformationResponse {
     username?: string;
   };
   product?: Data;
-  version?: string;
+  version: string;
   schema_hash?: string;
   storage_scenario?: Data;
   [key: string]: any;

--- a/source/util/get_schema_mapping.ts
+++ b/source/util/get_schema_mapping.ts
@@ -1,0 +1,11 @@
+// :copyright: Copyright (c) 2023 ftrack
+
+import { Schema } from "../types.js";
+
+export default function getSchemaMappingFromSchemas(schemas: Schema[]) {
+  const schemaMapping = {} as Record<string, Schema>;
+  for (const schema of schemas) {
+    schemaMapping[schema.id] = schema;
+  }
+  return schemaMapping;
+}

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -557,6 +557,10 @@ describe("Session", () => {
       queryServerInformation
     );
   });
+
+  it("Should support getting server version with session.getServerVersion()", async () => {
+    expect(await session.getServerVersion()).toEqual("dev");
+  });
 });
 
 describe("Encoding entities", () => {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -547,6 +547,16 @@ describe("Session", () => {
       })
     ).rejects.toThrowError("Code must be provided to enable totp.");
   });
+
+  it("Should support getting schemas with session.getSchemas()", async () => {
+    expect(await session.getSchemas()).toEqual(querySchemas);
+  });
+
+  it("Should support getting server information with session.getServerInformation()", async () => {
+    expect(await session.getServerInformation()).toEqual(
+      queryServerInformation
+    );
+  });
 });
 
 describe("Encoding entities", () => {


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

Longterm, to reduce initial session initialization time, we want to move away from having to call the `query_schemas` and `query_server_information` on initialization, and move it to being called lazily whenever asynchronous methods `session.getSchemas` or `session.getServerInformation` are called. 

This PR sets up these methods, and make some additional changes to make the future breaking change as easy as possible.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->

Make sure the methods work as intended, and haven't introduced any breaking changes.
