### PR TITLE
feat: Support for async subscriber callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "uuid": "^9.0.0"
   },
   "lint-staged": {
-    "*.js": "eslint --cache --fix",
-    "*.{js,css,md,json,jsx,scss,yml}": "prettier --write"
+    "*.{js,ts}": "eslint --cache --fix",
+    "*.{js,ts,css,md,json,jsx,scss,yml}": "prettier --write"
   },
   "packageManager": "yarn@3.6.1"
 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "uuid": "^9.0.0"
   },
   "lint-staged": {
-    "*.{js,ts}": "npx eslint --cache --fix",
-    "*.{js,ts,css,md,json,jsx,scss,yml}": "npx prettier --write"
+    "*.js": "eslint --cache --fix",
+    "*.{js,css,md,json,jsx,scss,yml}": "prettier --write"
   },
   "packageManager": "yarn@3.6.1"
 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "uuid": "^9.0.0"
   },
   "lint-staged": {
-    "*.{js,ts}": "eslint --cache --fix",
-    "*.{js,ts,css,md,json,jsx,scss,yml}": "prettier --write"
+    "*.{js,ts}": "npx eslint --cache --fix",
+    "*.{js,ts,css,md,json,jsx,scss,yml}": "npx prettier --write"
   },
   "packageManager": "yarn@3.6.1"
 }

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -583,6 +583,7 @@ export class EventHub {
           eventPayload
         );
       }
+         return promises; 
     }
   }
 

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -557,7 +557,7 @@ export class EventHub {
    */
   private _handle(eventPayload: EventPayload) {
     this.logger.debug("Event received", eventPayload);
-
+    const promises: Promise<any>[] = [];
     for (const subscriber of this._subscribers) {
       // TODO: Parse event target and check that it matches subscriber.
 
@@ -565,11 +565,12 @@ export class EventHub {
       if (!this._IsSubscriberInterestedIn(subscriber, eventPayload)) {
         continue;
       }
-    const promises: Promise<any>[] = [];
       try {
-        const responsePromise = Promise.resolve(subscriber.callback(eventPayload));
-                promises.push(responsePromise);
-        responsePromise.then(response => {
+        const responsePromise = Promise.resolve(
+          subscriber.callback(eventPayload)
+        );
+        promises.push(responsePromise);
+        responsePromise.then((response) => {
           // Publish reply if response isn't null or undefined.
           if (response != null) {
             this.publishReply(eventPayload, response, subscriber.metadata);
@@ -583,8 +584,8 @@ export class EventHub {
           eventPayload
         );
       }
-         return promises; 
     }
+    return promises;
   }
 
   /**

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -566,9 +566,15 @@ export class EventHub {
         continue;
       }
 
-      let response = null;
       try {
-        response = subscriber.callback(eventPayload);
+        const responsePromise = Promise.resolve(subscriber.callback(eventPayload));
+        
+        responsePromise.then(response => {
+          // Publish reply if response isn't null or undefined.
+          if (response != null) {
+            this.publishReply(eventPayload, response, subscriber.metadata);
+          }
+        });
       } catch (error) {
         this.logger.error(
           "Error calling subscriber for event.",
@@ -576,11 +582,6 @@ export class EventHub {
           subscriber,
           eventPayload
         );
-      }
-
-      // Publish reply if response isn't null or undefined.
-      if (response != null) {
-        this.publishReply(eventPayload, response, subscriber.metadata);
       }
     }
   }

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -565,7 +565,7 @@ export class EventHub {
       if (!this._IsSubscriberInterestedIn(subscriber, eventPayload)) {
         continue;
       }
-
+    const promises: Promise<any>[] = [];
       try {
         const responsePromise = Promise.resolve(subscriber.callback(eventPayload));
         

--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -568,7 +568,7 @@ export class EventHub {
     const promises: Promise<any>[] = [];
       try {
         const responsePromise = Promise.resolve(subscriber.callback(eventPayload));
-        
+                promises.push(responsePromise);
         responsePromise.then(response => {
           // Publish reply if response isn't null or undefined.
           if (response != null) {

--- a/source/session.ts
+++ b/source/session.ts
@@ -611,7 +611,7 @@ export class Session {
         if (reason instanceof Error) {
           throw this.getErrorFromResponse({
             exception: "NetworkError",
-            content: (reason.cause as string) || reason.message,
+            content: (reason["cause"] as string) || reason.message,
           });
         }
         throw new Error("Unknown error");

--- a/test/event_hub.test.js
+++ b/test/event_hub.test.js
@@ -152,4 +152,60 @@ describe("EventHub", () => {
 
     expect(callback).not.toHaveBeenCalledWith(testEvent);
   });
+
+  test("should handle async callback and return correct data", () => {
+    const callback = vi.fn(async () => {
+      return new Promise((resolve) => setTimeout(() => resolve("someData"), 1));
+    });
+    const testEvent = {
+      topic: "ftrack.test",
+      data: {},
+      id: "eventId",
+      source: { id: "sourceId" },
+    };
+
+    const publishReplySpy = vi
+      .spyOn(eventHub, "publishReply")
+      .mockImplementation((_, data) => data);
+
+    eventHub.subscribe("topic=ftrack.test", callback);
+    eventHub._handle(testEvent);
+
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalledWith(testEvent);
+      expect(publishReplySpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "someData",
+        expect.anything()
+      );
+    }, 10);
+    publishReplySpy.mockRestore();
+  });
+
+  test("should handle sync callback and return correct data", () => {
+    const callback = vi.fn(() => "someData");
+    const testEvent = {
+      topic: "ftrack.test",
+      data: {},
+      id: "eventId",
+      source: { id: "sourceId" },
+    };
+
+    const publishReplySpy = vi
+      .spyOn(eventHub, "publishReply")
+      .mockImplementation((_, data) => data);
+
+    eventHub.subscribe("topic=ftrack.test", callback);
+    eventHub._handle(testEvent);
+
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalledWith(testEvent);
+      expect(publishReplySpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "someData",
+        expect.anything()
+      );
+    }, 10);
+    publishReplySpy.mockRestore();
+  });
 });


### PR DESCRIPTION
Add support for async subscriber callbacks while retaining backwards compatibility.

- [ ] I have added automatic tests where applicable
- [X] The PR title is suitable as a release note
- [X] The PR contains a description of what has been changed
- [X] The description contains manual test instructions

## Changes
Made it possible to have an async subscriber callback.
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test
Check if subscribers are still called.
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
