### PR TITLE
fix: pre commit hooks broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "lint": "tsc && eslint . && prettier -c .",
     "test": "vitest --run test && yarn lint",
     "build": "vite build",
-    "prepack": "yarn build",
+    "prepack": "yarn build && pinst --disable",
     "prepublish": "yarn test",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "postpack": "pinst --enable"
   },
   "type": "module",
   "main": "./dist/ftrack-javascript-api.umd.cjs",
@@ -34,6 +35,7 @@
     "jsdom": "^22.1.0",
     "lint-staged": "^13.2.2",
     "msw": "^1.2.2",
+    "pinst": "^3.0.0",
     "prettier": "^2.8.8",
     "typescript": "^5.1.3",
     "vite": "^4.3.9",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "vitest --run test && yarn lint",
     "build": "vite build",
     "prepack": "yarn build",
-    "prepublish": "yarn test"
+    "prepublish": "yarn test",
+    "postinstall": "husky install"
   },
   "type": "module",
   "main": "./dist/ftrack-javascript-api.umd.cjs",
@@ -29,6 +30,7 @@
     "dayjs": "^1.11.8",
     "eslint": "^8.43.0",
     "eslint-config-react-app": "^7.0.1",
+    "husky": "^8.0.3",
     "jsdom": "^22.1.0",
     "lint-staged": "^13.2.2",
     "msw": "^1.2.2",
@@ -59,8 +61,8 @@
     "uuid": "^9.0.0"
   },
   "lint-staged": {
-    "*.js": "eslint --cache --fix",
-    "*.{js,css,md,json,jsx,scss,yml}": "prettier --write"
+    "*.{js,ts}": "eslint --cache --fix",
+    "*.{js,ts,css,md,json,jsx,scss,yml}": "prettier --write"
   },
   "packageManager": "yarn@3.6.1"
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "uuid": "^9.0.0"
   },
   "lint-staged": {
-    "*.{js,ts}": "eslint --cache --fix",
+    "*.{js,ts}": "eslint --cache --fix --max-warnings=0",
     "*.{js,ts,css,md,json,jsx,scss,yml}": "prettier --write"
   },
   "packageManager": "yarn@3.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,6 +1816,7 @@ __metadata:
     loglevel: ^1.8.1
     moment: ^2.29.4
     msw: ^1.2.2
+    pinst: ^3.0.0
     prettier: ^2.8.8
     typescript: ^5.1.3
     uuid: ^9.0.0
@@ -6237,6 +6238,15 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 8fbc073ede9209dd15e80d616e65eb674986c93be49f42d9ddde8dbbd141bb53d628a7ca4e58ab5c370bb00383f67d75df59a9a226dede8fa801267a7030c27a
+  languageName: node
+  linkType: hard
+
+"pinst@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pinst@npm:3.0.0"
+  bin:
+    pinst: bin.js
+  checksum: 4ae48a6a60f79c37071233af51b4d91bfc85cfa3c12b66ccda60cdb642b4d14a4ab0cb3587afc55b1f6192cea1772a5e4822026a0d0d3528296edef00cc2d61f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,6 +1810,7 @@ __metadata:
     dayjs: ^1.11.8
     eslint: ^8.43.0
     eslint-config-react-app: ^7.0.1
+    husky: ^8.0.3
     jsdom: ^22.1.0
     lint-staged: ^13.2.2
     loglevel: ^1.8.1
@@ -4660,6 +4661,15 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
+  bin:
+    husky: lib/bin.js
+  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Changes

Previous changes to the project accidentally removed the husky pre-commit hooks. This PR restores them.

## Test

Try committing something that would be stopped by eslint or fixed by prettier and make sure the appropriate action is taken.