### PR TITLE
docs: remove notice of event hub not supported in Node

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -44,10 +44,6 @@ instantiate a Session.::
     var ftrack = require('@ftrack/api');
     var session = new ftrack.Session(...)
 
-.. note::
-
-    Using the event hub from Node is currently not supported.
-
 
 Building distribution bundle from source
 ========================================


### PR DESCRIPTION
😏 🥳 🎉  