### PR TITLE
fix: window.addEventListener breaks node compatibility

### DIFF
--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -250,9 +250,11 @@ export default class SimpleSocketIOClient {
     this.reconnecting = false;
     this.webSocket?.close();
     this.webSocket = undefined;
-    window.addEventListener("online", this.attemptReconnect.bind(this), {
-      once: true,
-    });
+    if (typeof window !== "undefined" && window.addEventListener) {
+      window.addEventListener("online", this.attemptReconnect.bind(this), {
+        once: true,
+      });
+    }
     this.reconnect();
   }
   /**

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -250,7 +250,7 @@ export default class SimpleSocketIOClient {
     this.reconnecting = false;
     this.webSocket?.close();
     this.webSocket = undefined;
-    if (typeof window !== "undefined" && window.addEventListener) {
+    if (window?.addEventListener) {
       window.addEventListener("online", this.attemptReconnect.bind(this), {
         once: true,
       });


### PR DESCRIPTION
- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

My last minute addition of an online event handler to make reconnects faster was not node compatible since it uses window.addEventListener. This PR adds a conditional to only add the event-listener if it's actually possible.

## Test

