### PR TITLE
fix: undefined window throwing error on websocket close

### DIFF
--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -250,7 +250,7 @@ export default class SimpleSocketIOClient {
     this.reconnecting = false;
     this.webSocket?.close();
     this.webSocket = undefined;
-    if (window?.addEventListener) {
+    if (typeof window === "object" && window.addEventListener) {
       window.addEventListener("online", this.attemptReconnect.bind(this), {
         once: true,
       });


### PR DESCRIPTION

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes
Solves #154 

Previous solution of using `if (window?.addEventListener) {` only worked for non browser implementations where `window` was set as undefined, not which never sets `window` at all. This adds a more thorough check for non-browser implementations to catch errors.  

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
