### PR TITLE
feat: trigger reconnect on emit if not connected

### DIFF
--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -189,7 +189,7 @@ export class EventHub {
    * @return {Boolean}
    */
   isConnected(): boolean {
-    return this._socketIo?.isConnected() || false;
+    return this._socketIo?.socket.connected || false;
   }
 
   /**

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -55,7 +55,7 @@ export default class SimpleSocketIOClient {
   private packetQueue: string[] = [];
   private reconnectionAttempts: number = 0;
   private reconnecting: boolean = false;
-  initializingPromise: Promise<void>;
+  initializing: Promise<void>;
 
   // Added socket object with connected, open reconnect and transport properties to match current API
   // The old socket-io client uses both a connected and open property that are interchangeable
@@ -130,7 +130,7 @@ export default class SimpleSocketIOClient {
     this.heartbeatTimeoutMs = heartbeatTimeoutMs;
     this.apiUser = apiUser;
     this.apiKey = apiKey;
-    this.initializingPromise = this.initializeWebSocket();
+    this.initializing = this.initializeWebSocket();
   }
   /**
    * Fetches the session ID from the ftrack server.
@@ -407,7 +407,7 @@ export default class SimpleSocketIOClient {
    * @param randomizedDelay
    */
   private async attemptReconnect(): Promise<void> {
-    await this.initializingPromise;
+    await this.initializing;
     // Check if already connected or if active reconnection attempt ongoing.
     if (this.socket.connected || this.reconnecting) {
       return;
@@ -415,7 +415,7 @@ export default class SimpleSocketIOClient {
     this.reconnecting = true;
     this.reconnectionAttempts++;
     this.reconnectTimeout = undefined;
-    this.initializingPromise = this.initializeWebSocket();
+    this.initializing = this.initializeWebSocket();
     this.reconnect();
   }
   /**

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -55,7 +55,7 @@ export default class SimpleSocketIOClient {
   private packetQueue: string[] = [];
   private reconnectionAttempts: number = 0;
   private reconnecting: boolean = false;
-  private initializingPromise: Promise<void>;
+  initializingPromise: Promise<void>;
 
   // Added socket object with connected, open reconnect and transport properties to match current API
   // The old socket-io client uses both a connected and open property that are interchangeable

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -318,8 +318,6 @@ export default class SimpleSocketIOClient {
       this.webSocket.send(packet);
     } else {
       this.packetQueue.push(packet);
-    }
-    if (!this.socket.connected) {
       this.reconnect();
     }
   }

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -235,10 +235,10 @@ export default class SimpleSocketIOClient {
     }
     this.reconnecting = false;
     this.reconnectionAttempts = 0; // Reset reconnection attempts
-    this.handleEvent("connect", {});
-    this.flushPacketQueue();
     // Set connected property to true
     this.socket.connected = true;
+    this.handleEvent("connect", {});
+    this.flushPacketQueue();
   }
   /**
    * Handles WebSocket closing

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -313,10 +313,13 @@ export default class SimpleSocketIOClient {
     const dataString = eventData ? `:::${JSON.stringify(payload)}` : "";
     const packet = `${PACKET_TYPES.event}${dataString}`;
 
-    if (this.webSocket?.readyState === WebSocket.OPEN) {
+    if (this.isConnected()) {
       this.webSocket.send(packet);
     } else {
       this.packetQueue.push(packet);
+    }
+    if (this.webSocket && !this.socket.connected && !this.reconnecting) {
+      this.reconnect();
     }
   }
   /**

--- a/test/simple_socketio.test.js
+++ b/test/simple_socketio.test.js
@@ -410,6 +410,30 @@ describe("Tests using SimpleSocketIOClient", () => {
       `${PACKET_TYPES.event}${expectedDataString}`,
     );
   });
+  test("emit triggers a reconnect if not connected", () => {
+    client.webSocket = createWebSocketMock();
+    client.webSocket.readyState = WebSocket.CLOSED;
+
+    const reconnectSpy = vi.spyOn(client, "reconnect");
+
+    const eventName = "testEvent";
+    const eventData = { foo: "bar" };
+
+    client.emit(eventName, eventData);
+
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
+
+    const expectedPayload = {
+      name: eventName,
+      args: [eventData],
+    };
+    const expectedDataString = `:::${JSON.stringify(expectedPayload)}`;
+    expect(client.packetQueue).toContainEqual(
+      `${PACKET_TYPES.event}${expectedDataString}`,
+    );
+
+    reconnectSpy.mockRestore();
+  });
   describe("Reconnection tests", () => {
     test("attemptReconnect method initialises websocket again", async () => {
       client.initializeWebSocket = vi.fn();

--- a/test/simple_socketio.test.js
+++ b/test/simple_socketio.test.js
@@ -492,7 +492,7 @@ describe("Tests using SimpleSocketIOClient", () => {
         const expectedMaxDelay = expectedMinDelay * 1.5;
         client.reconnecting = false; // Since it never gets to the actual fail state triggered by
         client.reconnect();
-        await client.initializingPromise;
+        await client.initializing;
         vi.advanceTimersByTime(expectedMaxDelay + 1);
         expect(client.attemptReconnect).toHaveBeenCalledTimes(i + 1);
       }

--- a/test/simple_socketio.test.js
+++ b/test/simple_socketio.test.js
@@ -411,18 +411,18 @@ describe("Tests using SimpleSocketIOClient", () => {
     );
   });
   describe("Reconnection tests", () => {
-    test("attemptReconnect method initialises websocket again", () => {
+    test("attemptReconnect method initialises websocket again", async () => {
       client.initializeWebSocket = vi.fn();
 
-      client.attemptReconnect();
+      await client.attemptReconnect();
 
       expect(client.initializeWebSocket).toHaveBeenCalledTimes(1);
     });
 
-    test("attemptReconnect method increments attempts count", () => {
+    test("attemptReconnect method increments attempts count", async () => {
       const initialAttempts = client.reconnectionAttempts;
 
-      client.attemptReconnect();
+      await client.attemptReconnect();
 
       expect(client.reconnectionAttempts).toBe(initialAttempts + 1);
     });
@@ -456,7 +456,7 @@ describe("Tests using SimpleSocketIOClient", () => {
       // Reconnect should not be called yet
       expect(client.attemptReconnect).toHaveBeenCalledTimes(0);
     });
-    test("reconnect method exponentially increase delay for every attempt, stopping at the max value", () => {
+    test("reconnect method exponentially increase delay for every attempt, stopping at the max value", async () => {
       const originalRandom = Math.random;
       Math.random = vi.fn().mockReturnValue(1);
       vi.useFakeTimers();
@@ -468,6 +468,7 @@ describe("Tests using SimpleSocketIOClient", () => {
         const expectedMaxDelay = expectedMinDelay * 1.5;
         client.reconnecting = false; // Since it never gets to the actual fail state triggered by
         client.reconnect();
+        await client.initializingPromise;
         vi.advanceTimersByTime(expectedMaxDelay + 1);
         expect(client.attemptReconnect).toHaveBeenCalledTimes(i + 1);
       }


### PR DESCRIPTION
- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

Fixes an issue that halts reconnection attempts if the failed initialization takes longer than the time to attempt a new reconnection attempt.

Makes the reconnect behavior slightly more aggressive for clients using the WebSocket instance without using the EventServer*.

Took the opportunity to fix some naming inconsistencies.

*Legacy ftrack internal use case, there's no reason to replicate for anyone else

## Test

Is there any place this could break anything?