### PR TITLE
feat: dynamic import of socketio client

### DIFF
--- a/source/event_hub.ts
+++ b/source/event_hub.ts
@@ -1,7 +1,6 @@
 // :copyright: Copyright (c) 2016 ftrack
 import { v4 as uuidV4 } from "uuid";
 import loglevel from "loglevel";
-import io from "./simple_socketio.js";
 import { Event } from "./event.js";
 import {
   EventServerConnectionTimeoutError,
@@ -10,7 +9,7 @@ import {
   NotUniqueError,
 } from "./error.js";
 import { Data } from "./types.js";
-
+import type io from "./simple_socketio.js";
 interface BaseActionData {
   selection: Array<{
     entityId: string;
@@ -178,7 +177,9 @@ export class EventHub {
   }
 
   /** Connect to the event server. */
-  connect(): void {
+  async connect(): Promise<void> {
+    const simple_socketio = await import("./simple_socketio.js");
+    const io = simple_socketio.default;
     this._socketIo = io.connect(this._serverUrl, this._apiUser, this._apiKey);
     this._socketIo.on("connect", this._onSocketConnected);
     this._socketIo.on("ftrack.event", this._handle);


### PR DESCRIPTION
- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

To not require WS installed on Node instances that don't use the event server I changed the import for the socketIO client to be dynamic on connecting to the event server.

## Test

Does the socketio client still work in both browser and node? Are there any meaningful delay introduced?