### PR TITLE
fix: proper naming for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "type": "module",
   "main": "./dist/ftrack-javascript-api.umd.cjs",
-  "module": "./dist/ftrack-javascript-api.es.js",
+  "module": "./dist/ftrack-javascript-api.es.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/ftrack-javascript-api.es.js",
+      "import": "./dist/ftrack-javascript-api.es.mjs",
       "require": "./dist/ftrack-javascript-api.umd.cjs"
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       entry: path.resolve(__dirname, "source/index.ts"),
       name: "ftrack-javascript-api",
       fileName: (format) =>
-        `ftrack-javascript-api.${format}.${format === "umd" ? "cjs" : "js"}`,
+        `ftrack-javascript-api.${format}.${format === "umd" ? "cjs" : "mjs"}`,
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

This fixes a bug where node ESM code does not recognize it as ESM in Jest (and possibly ESM node applications too), because the file extension is not `.mjs`.

I see this has already been fixed for "cjs". This just does it for "mjs" as well. Confimed working.

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
