### PR TITLE
fix: Catch preflight errors on file upload

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -1090,7 +1090,7 @@ export class Session<
         },
       });
 
-      uploader.start();
+      uploader.start().catch(reject);
     });
   }
 }

--- a/source/uploader.ts
+++ b/source/uploader.ts
@@ -177,7 +177,14 @@ export class Uploader<TEntityTypeMap extends Record<string, any>> {
   /** Initiate upload. Promise is resolved once preflight is complete and upload started. */
   async start() {
     logger.debug("Upload starting", this.componentId);
-    await this.uploadPreflight();
+    try {
+      await this.uploadPreflight();
+    } catch (error) {
+      if (this.onError) {
+        this.onError(error);
+      }
+      return;
+    }
     if (!this.uploadMetadata) {
       throw new Error("Failed to get upload metadata");
     }

--- a/source/uploader.ts
+++ b/source/uploader.ts
@@ -181,7 +181,7 @@ export class Uploader<TEntityTypeMap extends Record<string, any>> {
       await this.uploadPreflight();
     } catch (error) {
       if (this.onError) {
-        this.onError(error);
+        this.onError(error as Error);
       }
       return;
     }

--- a/source/uploader.ts
+++ b/source/uploader.ts
@@ -183,7 +183,7 @@ export class Uploader<TEntityTypeMap extends Record<string, any>> {
       if (this.onError) {
         this.onError(error as Error);
       }
-      return;
+      throw error;
     }
     if (!this.uploadMetadata) {
       throw new Error("Failed to get upload metadata");


### PR DESCRIPTION
FT-6c8dae2f-08cf-4ed6-a119-d15c8d538fd0

- [ ] I have added automatic tests where applicable
- [X] The PR title is suitable as a release note
- [X] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

Includes changes related with catching errors on file upload on preflight phase.

Please also follow up [https://github.com/ftrackhq/ftrack-server/pull/750](https://github.com/ftrackhq/ftrack-server/pull/750)

## Test

- Try to upload one of the unallowed files and observe that snackbar on the top is displayed.
