### PR TITLE
fix: Conditionally add ftrack-api-options

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -663,9 +663,9 @@ export class Session<
             "ftrack-user": this.apiUser,
             "ftrack-Clienttoken": this.clientToken,
             "ftrack-pushtoken": pushToken,
-            "ftrack-api-options": ensureSerializableResponse
-              ? "strict:1;denormalize:1"
-              : undefined,
+            ...(ensureSerializableResponse && {
+              "ftrack-api-options": "strict:1;denormalize:1",
+            }),
             ...this.additionalHeaders,
             ...additionalHeaders,
           } as HeadersInit,

--- a/source/session.ts
+++ b/source/session.ts
@@ -663,9 +663,11 @@ export class Session<
             "ftrack-user": this.apiUser,
             "ftrack-Clienttoken": this.clientToken,
             "ftrack-pushtoken": pushToken,
-            ...(ensureSerializableResponse && {
-              "ftrack-api-options": "strict:1;denormalize:1",
-            }),
+            ...(ensureSerializableResponse
+              ? {
+                  "ftrack-api-options": "strict:1;denormalize:1",
+                }
+              : {}),
             ...this.additionalHeaders,
             ...additionalHeaders,
           } as HeadersInit,

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -229,6 +229,31 @@ describe("Session", () => {
     return expect((await headers).get("X-Test-Header")).toEqual("test");
   });
 
+  it("Should allow api option header based on ensureSerializableResponse", async () => {
+    const headers = new Promise<Headers>((resolve) => {
+      server.use(
+        http.post(
+          "http://ftrack.test/api",
+          (info) => {
+            resolve(info.request.headers as any);
+            return HttpResponse.json(getInitialSessionQuery());
+          },
+          { once: true },
+        ),
+      );
+    });
+
+    new Session(
+      credentials.serverUrl,
+      credentials.apiUser,
+      credentials.apiKey,
+      {
+        ensureSerializableResponse: false,
+      },
+    );
+    return expect((await headers).get("ftrack-api-options")).toBeFalsy();
+  });
+
   it("Should allow creating a User", () => {
     const promise = session.create("User", {
       username: getTestUsername(),


### PR DESCRIPTION


- [ ] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

- Conditionally add api-options.

## Test

