### PR TITLE
fix: wrap results in Partial<T>

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -643,7 +643,7 @@ export class Session<
       decodeDatesAsIso = this.decodeDatesAsIso,
       ensureSerializableResponse = this.ensureSerializableResponse,
     }: CallOptions = {},
-  ): Promise<IsTuple<T> extends true ? T : T[]> {
+  ): Promise<IsTuple<T> extends true ? Optional<T> : Optional<T>[]> {
     if (this.initializing) {
       await this.initializing;
     }
@@ -740,7 +740,7 @@ export class Session<
     entityType: TEntityType,
     data: TEntityTypeMap[TEntityType],
     identifyingKeys: Array<keyof TEntityTypeMap[TEntityType]> = [],
-  ): Promise<TEntityTypeMap[TEntityType]> {
+  ): Promise<Optional<TEntityTypeMap[TEntityType]>> {
     let keys = identifyingKeys as string[];
 
     const anyData = data as any;

--- a/source/session.ts
+++ b/source/session.ts
@@ -643,7 +643,7 @@ export class Session<
       decodeDatesAsIso = this.decodeDatesAsIso,
       ensureSerializableResponse = this.ensureSerializableResponse,
     }: CallOptions = {},
-  ): Promise<IsTuple<T> extends true ? Optional<T> : Optional<T>[]> {
+  ): Promise<IsTuple<T> extends true ? Partial<T> : Partial<T>[]> {
     if (this.initializing) {
       await this.initializing;
     }
@@ -740,7 +740,7 @@ export class Session<
     entityType: TEntityType,
     data: TEntityTypeMap[TEntityType],
     identifyingKeys: Array<keyof TEntityTypeMap[TEntityType]> = [],
-  ): Promise<Optional<TEntityTypeMap[TEntityType]>> {
+  ): Promise<Partial<TEntityTypeMap[TEntityType]>> {
     let keys = identifyingKeys as string[];
 
     const anyData = data as any;


### PR DESCRIPTION
We discussed this some months back (I think it was with @gismya in another PR or issue somewhere).

It is a good idea to wrap results coming from the server in `Optional<T>`. That way, we can then make some nice typing tricks over at the TS generator project (such as always making array properties like "custom_attributes" non-nullable, saving us from a lot of checks in general).