### PR TITLE
fix: server information license typing issue

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -81,7 +81,12 @@ export interface ServerInformation {
   custom_widget?: Data;
   default_colors?: string[];
   is_nested_subqueries_enabled?: boolean;
-  license?: string[];
+  license?: {
+    feature_id: string;
+    quantity: number;
+    renewal_date: string;
+    date: string;
+  }[];
   preferred_language?: string;
   week_startday?: number;
   workday_length?: number;


### PR DESCRIPTION
Updates the typing for server information license to be an array of objects instead of an array of strings.

I currently get this from the server:

`[{
    "date": "2024-10-20",
    "feature_id": "ftrack-enterprise",
    "quantity": 2500,
    "renewal_date": "2024-10-20"
}]`