### PR TITLE
chore: Make ws dependency optional for node.js environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/node": "^22.13.9",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.0",
     "@vitest/eslint-plugin": "^1.1.36",
     "dayjs": "^1.11.13",
     "eslint": "^9.21.0",
@@ -60,7 +61,6 @@
   },
   "homepage": "http://ftrack.com",
   "dependencies": {
-    "isomorphic-ws": "^5.0.0",
     "loglevel": "^1.9.2",
     "moment": "^2.30.1",
     "uuid": "^11.1.0"

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -171,11 +171,12 @@ export default class SimpleSocketIOClient {
         this.reconnecting = false;
       }
       const urlWithQueryAndSession = `${this.webSocketUrl}/socket.io/1/websocket/${sessionId}?${this.query}`;
-      let WebSocketImpl = WebSocket;
-      if (typeof WebSocketImpl === "undefined") {
-        WebSocketImpl = (await import("ws"))
-          .default as unknown as typeof WebSocket;
-      }
+      const WebSocketImpl =
+        typeof WebSocket === "undefined"
+          ? // Fallback on ws package if WebSocket is not available
+            ((await import("ws")).default as typeof WebSocket)
+          : WebSocket;
+
       this.webSocket = new WebSocketImpl(urlWithQueryAndSession);
       // Set transport.websocket property as a public alias of the websocket
       this.socket.transport.websocket = this.webSocket;

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -1,5 +1,4 @@
 // :copyright: Copyright (c) 2023 ftrack
-import WebSocket from "isomorphic-ws";
 import { Event } from "./event.js";
 export const PACKET_TYPES = {
   disconnect: "0",
@@ -42,7 +41,7 @@ interface Payload {
  */
 export default class SimpleSocketIOClient {
   private static instances: Map<string, SimpleSocketIOClient> = new Map();
-  private webSocket: WebSocket;
+  private webSocket: WebSocket | undefined;
   private handlers: EventHandlers = {};
   private reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
   private heartbeatTimeout: ReturnType<typeof setInterval> | undefined;
@@ -172,7 +171,12 @@ export default class SimpleSocketIOClient {
         this.reconnecting = false;
       }
       const urlWithQueryAndSession = `${this.webSocketUrl}/socket.io/1/websocket/${sessionId}?${this.query}`;
-      this.webSocket = new WebSocket(urlWithQueryAndSession);
+      let WebSocketImpl = WebSocket;
+      if (typeof WebSocketImpl === "undefined") {
+        WebSocketImpl = (await import("ws"))
+          .default as unknown as typeof WebSocket;
+      }
+      this.webSocket = new WebSocketImpl(urlWithQueryAndSession);
       // Set transport.websocket property as a public alias of the websocket
       this.socket.transport.websocket = this.webSocket;
       this.addInitialEventListeners(this.webSocket);
@@ -195,7 +199,7 @@ export default class SimpleSocketIOClient {
    * Handles WebSocket errors
    * @private
    */
-  private handleError(event: Event): void {
+  private handleError(event: WebSocketEventMap["error"]): void {
     this.handleClose();
     console.error("WebSocket error:", event);
   }
@@ -322,7 +326,7 @@ export default class SimpleSocketIOClient {
     const packet = `${PACKET_TYPES.event}${dataString}`;
 
     if (this.isConnected()) {
-      this.webSocket.send(packet);
+      this.webSocket?.send(packet);
     } else {
       this.packetQueue.push(packet);
       this.reconnect();
@@ -436,9 +440,9 @@ export default class SimpleSocketIOClient {
     this.packetQueue = [];
 
     if (this.webSocket) {
-      this.webSocket.onclose = undefined;
-      this.webSocket.onerror = undefined;
-      this.webSocket?.close();
+      this.webSocket.onclose = null;
+      this.webSocket.onerror = null;
+      this.webSocket.close();
       this.webSocket = undefined;
     }
     if (this.reconnectTimeout) {

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -27,8 +27,7 @@ class MockXmlHttpRequest extends EventTarget {
 }
 
 beforeAll(() => {
-  server.listen({ onUnhandledRequest: "bypass" });
-  global.fetch = fetch;
+  server.listen({ onUnhandledRequest: "error" });
   global.XMLHttpRequest = MockXmlHttpRequest;
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,12 +394,12 @@ __metadata:
   dependencies:
     "@types/node": "npm:^22.13.9"
     "@types/uuid": "npm:^10.0.0"
+    "@types/ws": "npm:^8.18.0"
     "@vitest/eslint-plugin": "npm:^1.1.36"
     dayjs: "npm:^1.11.13"
     eslint: "npm:^9.21.0"
     globals: "npm:^16.0.0"
     husky: "npm:^9.1.7"
-    isomorphic-ws: "npm:^5.0.0"
     jsdom: "npm:^26.0.0"
     lint-staged: "npm:^15.4.3"
     loglevel: "npm:^1.9.2"
@@ -900,12 +900,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.13.9":
-  version: 22.13.9
-  resolution: "@types/node@npm:22.13.9"
+"@types/node@npm:*, @types/node@npm:^22.13.9":
+  version: 22.13.10
+  resolution: "@types/node@npm:22.13.10"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10/23560df3ee99c907179c688754486b969a72144f2e2bdefe974d320dddc5ca8f93365842966ecbd5c5bba34e919fc1a5a6627712beb8e7f71d71347dcf414a35
+  checksum: 10/57dc6a5e0110ca9edea8d7047082e649fa7fa813f79e4a901653b9174141c622f4336435648baced5b38d9f39843f404fa2d8d7a10981610da26066bc8caab48
   languageName: node
   linkType: hard
 
@@ -927,6 +927,15 @@ __metadata:
   version: 10.0.0
   resolution: "@types/uuid@npm:10.0.0"
   checksum: 10/e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.0":
+  version: 8.18.0
+  resolution: "@types/ws@npm:8.18.0"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/2a3bbf27690532627bfde8a215c0cf3a56680f339f972785b30d0b4665528275b9270c0a0839244610b0a3f2da4218c6dd741ceba1d173fde5c5091f2034b823
   languageName: node
   linkType: hard
 
@@ -2836,15 +2845,6 @@ __metadata:
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: 10/7c9f715c03aff08f35e98b1fadae1b9267b38f0615d501824f9743f3aab99ef10e303ce7db3f186763a0b70a19de5791ebfc854ff884d5a8c4d92211f642ec92
-  languageName: node
-  linkType: hard
-
-"isomorphic-ws@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "isomorphic-ws@npm:5.0.0"
-  peerDependencies:
-    ws: "*"
-  checksum: 10/e20eb2aee09ba96247465fda40c6d22c1153394c0144fa34fe6609f341af4c8c564f60ea3ba762335a7a9c306809349f9b863c8beedf2beea09b299834ad5398
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

As Node >= 21 has a built-in websocket client, it's preferable to not having to rely on the `ws` dependency through `isomorphic-ws` for Node, but rather check if WebSocket is available in the global namespace, and only load `ws` if not. 


Once Node 20 becomes EOL (2026-04-30) we can remove ws as well and only rely on undici's WebSocket.  

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
