### PR TITLE
fix: npm publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,4 +13,3 @@ jobs:
       packageUrl: https://www.npmjs.com/package/@ftrack/api
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
-      npmToken: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

After [updating npm publishing script](https://github.com/ftrackhq/ftrack-actions/pull/34) to adhere to new security standards, we now need to update the npm script here as well since we removed the npm token argument, and it refuses to run when having included unknown args:



## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
