### PR TITLE
chore(deps): batch renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": ["config:recommended"],
   "enabledManagers": ["npm", "github-actions"],
   "rangeStrategy": "update-lockfile",
-  "schedule": ["every month"]
+  "schedule": ["every month"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm", "github-actions"],
+      "groupName": "all dependency updates",
+      "separateMajorMinor": true
+    }
+  ]
 }


### PR DESCRIPTION
Resolves N/A

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
- Adds a Renovate package rule for the enabled `npm` and `github-actions` managers.
- Applies a shared group name so matching dependency updates are grouped together under the same Renovate bucket.
- Keeps the existing `update-lockfile` range strategy unchanged.

## Test
- Run `npx --yes --package renovate -- renovate-config-validator --no-global /Users/jimmy/dev/ftrack-javascript/renovate.json`
- Confirm the validator reports `Config validated successfully`.
