### PR TITLE
fix(session): don't log aborted requests as failed requests

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -624,6 +624,13 @@ export class Session<
         });
       } catch (reason) {
         if (reason instanceof Error) {
+          // A request cancelled via AbortSignal rejects fetch with an
+          // AbortError. Let it propagate unchanged so the outer handler treats
+          // it as an expected cancellation (debug) rather than wrapping it in a
+          // NetworkError and logging a failed request.
+          if (reason.name === "AbortError") {
+            throw reason;
+          }
           throw this.getErrorFromResponse({
             exception: "NetworkError",
             content: (reason["cause"] as string) || reason.message,

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,5 +1,5 @@
 // :copyright: Copyright (c) 2022 ftrack
-import { beforeAll, describe, it, expect } from "vitest";
+import { beforeAll, describe, it, expect, vi } from "vitest";
 
 import { v4 as uuidV4 } from "uuid";
 import loglevel from "loglevel";
@@ -8,6 +8,7 @@ import {
   ServerPermissionDeniedError,
   ServerValidationError,
   ServerError,
+  AbortError,
 } from "../source/error.js";
 import { Session, expression } from "../source/session.js";
 import * as operation from "../source/operation.js";
@@ -548,6 +549,24 @@ describe("Session", () => {
     await expect(() =>
       session.call([{ action: "configure_totp", secret, code }]),
     ).rejects.toThrowError("Code must be provided to enable totp.");
+  });
+
+  it("Throws AbortError, without logging a failed request, when aborted", async () => {
+    const apiLogger = loglevel.getLogger("ftrack_api");
+    const warnSpy = vi.spyOn(apiLogger, "warn");
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(() =>
+      session.call([operation.query("select id from Task")], {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(AbortError);
+
+    // An aborted request is an expected cancellation, not a failure.
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it("Should support getting schemas with session.getSchemas()", async () => {


### PR DESCRIPTION
## Problem

When a request is cancelled via an `AbortSignal`, `fetch` rejects with an `AbortError`. The inner `fetch` `catch` in `Session.call` wraps *every* error — including the abort — into a `NetworkError` before the outer handler's `AbortError` check runs. So a routine cancellation (e.g. a React component unmounting mid-request, or React Query superseding a query) is:

- logged as `Failed to perform request.` at **warn** level, and
- surfaced to the caller as a `ServerError` instead of an `AbortError`.

The outer handler already intends to treat aborts as expected cancellations (logged at `debug`, thrown as `AbortError`), but never sees them because the inner catch has already re-wrapped the error.

## Fix

Let `AbortError` propagate unchanged from the inner `catch` so the outer handler classifies it correctly.

## Test

Adds a `session.test.ts` case asserting that an aborted request throws `AbortError` (not a wrapped `ServerError`) and does not log a failed-request warning. Fails before the change, passes after.

Verified: full `vitest` suite (165 passed), `tsc`, `eslint` (0 errors), `prettier -c` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled requests. Aborted requests are now properly treated as intentional cancellations rather than network failures, preventing false error warnings in logs.

* **Tests**
  * Added test coverage for request cancellation behavior to ensure aborted requests are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->