### PR TITLE
chore: drop ws dependency, use native WebSocket (Node >=22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
     "dist"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@types/node": "^24.10.8",
     "@types/uuid": "^11.0.0",
-    "@types/ws": "^8.18.1",
     "@vitest/eslint-plugin": "^1.6.6",
     "dayjs": "^1.11.19",
     "eslint": "^10.0.0",
@@ -46,8 +45,7 @@
     "typescript-eslint": "^8.57.2",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "^4.1.0",
-    "ws": "^8.19.0"
+    "vitest": "^4.1.0"
   },
   "repository": {
     "type": "git",
@@ -67,14 +65,6 @@
   "dependencies": {
     "loglevel": "^1.9.2",
     "uuid": "^14.0.0"
-  },
-  "peerDependencies": {
-    "ws": "^8.13.0"
-  },
-  "peerDependenciesMeta": {
-    "ws": {
-      "optional": true
-    }
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --cache --fix --max-warnings=0",

--- a/source/simple_socketio.ts
+++ b/source/simple_socketio.ts
@@ -171,13 +171,7 @@ export default class SimpleSocketIOClient {
         this.reconnecting = false;
       }
       const urlWithQueryAndSession = `${this.webSocketUrl}/socket.io/1/websocket/${sessionId}?${this.query}`;
-      const WebSocketImpl =
-        typeof WebSocket === "undefined"
-          ? // Fallback on ws package if WebSocket is not available
-            ((await import("ws")).default as typeof WebSocket)
-          : WebSocket;
-
-      this.webSocket = new WebSocketImpl(urlWithQueryAndSession);
+      this.webSocket = new WebSocket(urlWithQueryAndSession);
       // Set transport.websocket property as a public alias of the websocket
       this.socket.transport.websocket = this.webSocket;
       this.addInitialEventListeners(this.webSocket);

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,7 +256,6 @@ __metadata:
     "@eslint/js": "npm:^10.0.0"
     "@types/node": "npm:^24.10.8"
     "@types/uuid": "npm:^11.0.0"
-    "@types/ws": "npm:^8.18.1"
     "@vitest/eslint-plugin": "npm:^1.6.6"
     dayjs: "npm:^1.11.19"
     eslint: "npm:^10.0.0"
@@ -274,12 +273,6 @@ __metadata:
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
     vitest: "npm:^4.1.0"
-    ws: "npm:^8.19.0"
-  peerDependencies:
-    ws: ^8.13.0
-  peerDependenciesMeta:
-    ws:
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -767,15 +760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 25.5.0
-  resolution: "@types/node@npm:25.5.0"
-  dependencies:
-    undici-types: "npm:~7.18.0"
-  checksum: 10/b1e8116bd8c9ff62e458b76d28a59cf7631537bb17e8961464bf754dd5b07b46f1620f568b2f89970505af9eef478dd74c614651b454c1ea95949ec472c64fcb
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^24.10.8":
   version: 24.12.0
   resolution: "@types/node@npm:24.12.0"
@@ -798,15 +782,6 @@ __metadata:
   dependencies:
     uuid: "npm:*"
   checksum: 10/9f94bd34e5d220c53cc58ea9f48a0061d3bc343e29bc33a17edc705f5e21fedda21553318151f2bc227c2b2b03727bbb536da2b82a61f84d2e1ca38abc5e5c3f
-  languageName: node
-  linkType: hard
-
-"@types/ws@npm:^8.18.1":
-  version: 8.18.1
-  resolution: "@types/ws@npm:8.18.1"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/1ce05e3174dcacf28dae0e9b854ef1c9a12da44c7ed73617ab6897c5cbe4fccbb155a20be5508ae9a7dde2f83bd80f5cf3baa386b934fc4b40889ec963e94f3a
   languageName: node
   linkType: hard
 
@@ -3948,13 +3923,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.18.0":
-  version: 7.18.2
-  resolution: "undici-types@npm:7.18.2"
-  checksum: 10/e61a5918f624d68420c3ca9d301e9f15b61cba6e97be39fe2ce266dd6151e4afe424d679372638826cb506be33952774e0424141200111a9857e464216c009af
-  languageName: node
-  linkType: hard
-
 "undici@npm:^7.24.5":
   version: 7.24.6
   resolution: "undici@npm:7.24.6"
@@ -4291,21 +4259,6 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10/159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.19.0":
-  version: 8.20.0
-  resolution: "ws@npm:8.20.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/b7ab934b21ffdea9f25a5af5097e8c1ec7625db553bca026c5a23e35b7c236f3fb89782f2b57fab9da553864512f9aa7d245827ef998d26ffa1b2187a19a6d10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Remove the `ws` package entirely: the optional peer dependency, `@types/ws`, and the `ws` devDependency.
- Bump `engines.node` from `>=20.0.0` to `>=22.0.0`.
- Simplify `SimpleSocketIOClient` to use the global `WebSocket` directly.

## Why

`SimpleSocketIOClient` already preferred the native global `WebSocket` and only fell back to `ws` when it was undefined — i.e. on Node versions without a built-in WebSocket. Node 22 ships a **stable global `WebSocket`**, so that fallback (and the whole `ws` dependency) is dead weight.

Node 20 reached EOL in April 2026, and `.nvmrc` / CI already run on Node 24, so raising the floor to Node 22 costs nothing and lets us drop a dependency.

## Verification

`ws` is fully removed from the dependency tree — it's gone from `yarn.lock`, nothing else pulls it in (msw uses its own internal WebSocket interception, not the npm `ws` package).

- `yarn vitest --run test` → 165 passed, 4 skipped. **Caveat:** tests run under jsdom + msw, which always define/mock `WebSocket`, so they never exercised the old `ws` fallback and don't on their own prove a real Node runtime.
- To close that gap: in a Node 24 runtime with **no `ws` installed**, a native-global `WebSocket` client (the exact path the library now uses) connected, sent, received, and closed against a WebSocket server — events `['open', 'msg:echo:ping', 'close']`. Native global `WebSocket` is stable from Node 22 onward, which is the new floor.
- `yarn lint` (tsc + eslint + prettier) → 0 errors.

Browsers have had global `WebSocket` forever, so this only affects the Node side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)