### PR TITLE
chore: remove redundant dev dependencies (@types/uuid, pinst)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
     "lint": "tsc && eslint . && prettier -c .",
     "test": "vitest --run test && yarn lint",
     "build": "vite build",
-    "prepack": "yarn build && pinst --disable",
+    "prepack": "yarn build",
     "prepublish": "yarn test",
-    "postinstall": "husky install",
-    "postpack": "pinst --enable"
+    "prepare": "husky"
   },
   "type": "module",
   "main": "./dist/ftrack-javascript-api.umd.cjs",
@@ -30,7 +29,6 @@
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@types/node": "^24.10.8",
-    "@types/uuid": "^11.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/eslint-plugin": "^1.6.6",
     "dayjs": "^1.11.19",
@@ -40,7 +38,6 @@
     "jsdom": "^29.0.0",
     "lint-staged": "^16.2.7",
     "msw": "^2.12.7",
-    "pinst": "^3.0.0",
     "prettier": "^3.7.4",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.57.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,7 +255,6 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^10.0.0"
     "@types/node": "npm:^24.10.8"
-    "@types/uuid": "npm:^11.0.0"
     "@types/ws": "npm:^8.18.1"
     "@vitest/eslint-plugin": "npm:^1.6.6"
     dayjs: "npm:^1.11.19"
@@ -266,7 +265,6 @@ __metadata:
     lint-staged: "npm:^16.2.7"
     loglevel: "npm:^1.9.2"
     msw: "npm:^2.12.7"
-    pinst: "npm:^3.0.0"
     prettier: "npm:^3.7.4"
     typescript: "npm:^6.0.0"
     typescript-eslint: "npm:^8.57.2"
@@ -789,15 +787,6 @@ __metadata:
   version: 2.0.6
   resolution: "@types/statuses@npm:2.0.6"
   checksum: 10/dadfbb4f32a16d3106a8e2a957dab17b1ae99fc4788e1fd96aeaf82355e3b2b069d5ea0f5fb887efa830def033828955a5bbdfd35454ba2088822537aed9e5db
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "@types/uuid@npm:11.0.0"
-  dependencies:
-    uuid: "npm:*"
-  checksum: 10/9f94bd34e5d220c53cc58ea9f48a0061d3bc343e29bc33a17edc705f5e21fedda21553318151f2bc227c2b2b03727bbb536da2b82a61f84d2e1ca38abc5e5c3f
   languageName: node
   linkType: hard
 
@@ -3211,15 +3200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pinst@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pinst@npm:3.0.0"
-  bin:
-    pinst: bin.js
-  checksum: 10/a75e4f7b5eeb9c76e7fd1b2d9854fcd38c304a3b1f9b563946a0f4357772c742222094e851f4c23d0bbdc4151af2d7875bb919c9ef8a9c4af77a02a73e8f72f0
-  languageName: node
-  linkType: hard
-
 "pkg-types@npm:^1.3.0":
   version: 1.3.1
   resolution: "pkg-types@npm:1.3.1"
@@ -4007,15 +3987,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:*":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removes two devDependencies that are no longer pulling their weight.

## `@types/uuid`

uuid v14 ships its own type declarations (`"types": "./dist/index.d.ts"`), so the separate `@types/uuid@^11` stub is dead weight — a leftover from older uuid versions. `tsc` passes without it.

## `pinst`

`pinst` existed only to neutralise `postinstall: husky install` when publishing (so consumers don't run husky). But husky is already **v9**, where:

- `husky install` is deprecated — the command is now just `husky`, and
- the recommended setup is `"prepare": "husky"`. `prepare` doesn't run when the package is installed as a dependency, so the whole pinst dance (`postinstall` + `prepack --disable` / `postpack --enable`) is unnecessary.

So this also modernises the husky config:

```diff
- "prepack": "yarn build && pinst --disable",
+ "prepack": "yarn build",
- "postinstall": "husky install",
- "postpack": "pinst --enable"
+ "prepare": "husky"
```

`.husky/pre-commit` is already v9 format, so nothing else changes.

## Verification

- `yarn lint` (tsc + eslint + prettier) → **0 errors** (tsc confirms uuid's bundled types are sufficient).
- `yarn vitest --run test` → 165 passed, 4 skipped.
- After `yarn install`, the `prepare` script set up `.husky/_` and `core.hooksPath`; the pre-commit hook fired on this commit.

## Note

Independent of #391 (drop `ws`). Both touch the `devDependencies` block, so whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined package build and release lifecycle scripts for improved efficiency and maintainability.
  * Removed unnecessary development dependencies to reduce installation footprint and simplify the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->